### PR TITLE
chore: fix tip to mention correct command to follow logs for existing task

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -191,7 +191,7 @@ export const listCommand = async (options: { watch?: boolean; verbose?: boolean;
         console.log('');
         console.log(colors.gray('Tips:'));
         console.log(colors.gray('  Use ') + colors.cyan('rover list --verbose') + colors.gray(' to see error details'));
-        console.log(colors.gray('  Use ') + colors.cyan('rover task <id> --follow') + colors.gray(' to follow logs'));
+        console.log(colors.gray('  Use ') + colors.cyan('rover logs <id> --follow') + colors.gray(' to follow logs'));
         console.log(colors.gray('  Use ') + colors.cyan('rover diff <id>') + colors.gray(' to see changes'));
 
         // Watch mode (simple refresh every 5 seconds)


### PR DESCRIPTION
## Summary
Fixes an incorrect command reference in the help tip displayed by `rover list`. 

## Changes
- Updates the tip text to correctly reference `rover logs <id> --follow` instead of `rover task <id> --follow` for following task logs
- This ensures users get the correct command when they want to follow logs for an existing task

## Impact
Users will now see the correct command syntax when using `rover list`, improving the user experience and reducing confusion.