### PR TITLE
feat: add the createTaskFromGitHub command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -91,6 +91,12 @@
         "title": "Open Task Workspace",
         "icon": "$(folder-opened)",
         "category": "Rover"
+      },
+      {
+        "command": "rover.createTaskFromGitHub",
+        "title": "Create Task from GitHub Issue",
+        "icon": "$(github)",
+        "category": "Rover"
       }
     ],
     "menus": {
@@ -104,6 +110,11 @@
           "command": "rover.createTask",
           "when": "view == roverTasks",
           "group": "navigation@2"
+        },
+        {
+          "command": "rover.createTaskFromGitHub",
+          "when": "view == roverTasks",
+          "group": "navigation@3"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
Add a new command to create tasks from GitHub issues. The extension will try to fetch the data from the repository using the GitHub public API and the `gh` CLI. In any other case, it will fallback to asking for the task ID (which might fail too due to not having access to the task description).

Refs #10 

## Demo

<img width="1728" height="1146" alt="Captura de pantalla 2025-08-05 a las 12 12 40" src="https://github.com/user-attachments/assets/1fb11fae-4d2c-49dd-aaca-f8de9f65bcae" />

