### PR TITLE
feat: add --json to push command and integrate it as an action in vscode extension

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -75,6 +75,12 @@
         "category": "Rover"
       },
       {
+        "command": "rover.pushBranch",
+        "title": "Push a task branch",
+        "icon": "$(info)",
+        "category": "Rover"
+      },
+      {
         "command": "rover.deleteTask",
         "title": "Delete Task",
         "icon": "$(trash)",

--- a/extension/src/providers/TasksWebviewProvider.ts
+++ b/extension/src/providers/TasksWebviewProvider.ts
@@ -45,6 +45,9 @@ export class TasksWebviewProvider implements vscode.WebviewViewProvider {
                 case 'gitCompare':
                     await this.handleGitCompareTask(data.taskId);
                     break;
+                case 'pushBranch':
+                    await this.handlePushBranch(data.taskId);
+                    break;
                 case 'deleteTask':
                     await this.handleDeleteTask(data.taskId, data.taskTitle);
                     break;
@@ -88,6 +91,10 @@ export class TasksWebviewProvider implements vscode.WebviewViewProvider {
 
     private async handleGitCompareTask(taskId: string) {
         await vscode.commands.executeCommand('rover.gitCompareTask', { id: taskId, task: { id: taskId } });
+    }
+
+    private async handlePushBranch(taskId: string) {
+        await vscode.commands.executeCommand('rover.pushBranch', { id: taskId, task: { id: taskId } });
     }
 
     private async handleDeleteTask(taskId: string, taskTitle: string) {
@@ -478,6 +485,13 @@ export class TasksWebviewProvider implements vscode.WebviewViewProvider {
             });
         }
 
+        function pushBranch(taskId) {
+            vscode.postMessage({
+                command: 'pushBranch',
+                taskId: taskId
+            });
+        }
+
         function viewLogs(taskId, taskStatus) {
             vscode.postMessage({
                 command: 'viewLogs',
@@ -528,7 +542,7 @@ export class TasksWebviewProvider implements vscode.WebviewViewProvider {
                             \${task.status === 'TODO' ? 
                                 \`<button class="action-btn" onclick="event.stopPropagation(); mergeTask('\${task.id}')" title="Merge Task"><i class="codicon codicon-git-merge"></i></button>\` : ''
                             }
-                            \${task.status === 'TODO' ? 
+                            \${task.status === 'completed' ? 
                                 \`<button class="action-btn" onclick="event.stopPropagation(); pushBranch('\${task.id}')" title="Push Task Branch"><i class="codicon codicon-repo-push"></i></button>\` : ''
                             }
                             <button class="action-btn" onclick="event.stopPropagation(); viewLogs('\${task.id}', '\${task.status}')" title="View Logs">

--- a/extension/src/rover/cli.ts
+++ b/extension/src/rover/cli.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as vscode from 'vscode';
-import { RoverTask, TaskDetails } from './types';
+import { PushResult, RoverTask, TaskDetails } from './types';
 
 const execAsync = promisify(exec);
 
@@ -46,6 +46,14 @@ export class RoverCLI {
     async createTask(description: string): Promise<RoverTask> {
         const { stdout } = await execAsync(`${this.roverPath} task "${description}" --yes --json`, this.getExecOptions());
         return JSON.parse(stdout) as RoverTask;
+    }
+
+    /**
+     * Push branch
+     */
+    async pushBranch(taskId: string, commit: string): Promise<PushResult> {
+        const { stdout } = await execAsync(`${this.roverPath} push "${taskId}" --message "${commit}" --json`, this.getExecOptions());
+        return JSON.parse(stdout) as PushResult;
     }
 
     /**

--- a/extension/src/rover/types.ts
+++ b/extension/src/rover/types.ts
@@ -20,3 +20,20 @@ export interface TaskDetails extends RoverTask {
         completedAt?: string;
     }>;
 }
+
+export interface PushResult {
+    success: boolean;
+    taskId: number;
+    taskTitle: string;
+    branchName: string;
+    hasChanges: boolean;
+    committed: boolean;
+    commitMessage?: string;
+    pushed: boolean;
+    pullRequest?: {
+        created: boolean;
+        url?: string;
+        exists?: boolean;
+    };
+    error?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,8 +132,9 @@ program
 	.description('Commit and push task changes to remote, with GitHub PR support')
 	.argument('<taskId>', 'Task ID to push')
 	.option('-m, --message <message>', 'Commit message')
-	.option('--no-pr', 'Skip pull request creation prompt')
+	.option('--pr', 'Creates a Pull Request in GitHub')
 	.option('-f, --force', 'Force push')
+	.option('--json', 'Output in JSON format')
 	.action(pushCommand);
 
 program.parse(process.argv);


### PR DESCRIPTION
Add support for pushing the task branch into a remote repository. In VSCode, it asks for the commit message and pushes the task branch right away.

Refs #15 

## Changes

- Add the `--json` option to the `rover push` command
- Add the `rover.pushBranch` action to the extension
- Add the push branch button to the tasks list