### PR TITLE
fix: use git status -u to show untracked files in folders

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -238,7 +238,7 @@ export function activate(context: vscode.ExtensionContext) {
                 // Get list of changed files in the task workspace
                 let changedFiles: string[] = [];
                 try {
-                    const { stdout: statusOutput } = await execAsync('git status --porcelain', { cwd: taskWorkspacePath });
+                    const { stdout: statusOutput } = await execAsync('git status --porcelain -u', { cwd: taskWorkspacePath });
                     changedFiles = statusOutput.split('\n')
                         .filter(line => line.trim())
                         .map(line => line.substring(3).trim()) // Remove status flags (e.g., "M ", "A ", etc.)


### PR DESCRIPTION
Fix the diff view by including all files in the `git status --porcelain` command using the `-u` (show untracked) option.

Closes #26 

## Demo

<img width="1582" height="1030" alt="Captura de pantalla 2025-08-06 a las 12 05 46" src="https://github.com/user-attachments/assets/c9a0298d-6ba1-45e2-8966-cfa5089e7e0d" />
