### PR TITLE
feat: consolidate iteration metadata into iteration.json

### DIFF
--- a/packages/cli/src/lib/docker.ts
+++ b/packages/cli/src/lib/docker.ts
@@ -1,0 +1,111 @@
+import { ChildProcessByStdio, spawn, spawnSync } from 'node:child_process';
+import Stream from 'node:stream';
+
+export class DockerError extends Error {
+    constructor(reason: string) {
+        super(`Error running docker command. Reason: ${reason}`);
+        this.name = 'DockerError';
+    }
+}
+
+/**
+ * A class to manage and run docker commands
+ */
+export class Docker {
+    constructor() {
+        // Check docker is available
+        if (spawnSync('docker', ['--version'], { stdio: 'pipe' }).error) {
+            throw new DockerError('Docker is not installed or the daemon is stopped.');
+        }
+    }
+
+    /**
+     * Starts a container based on the given arguments
+     * 
+     * @param name Container name
+     * @param image Container image
+     * @param mounts Array of mount commands
+     * @param workspace User workspace
+     * @param cmd The command to pass to docker and its arguments
+     * @param extraArgs Other arguments like user
+     */
+    startContainer(name: string, image: string, mounts: string[], workspace: string, cmd: string[], extraArgs: string[] = []): boolean {
+        // First, remove any existing container with the same name
+        this.removeContainer(name);
+
+        // Build docker run command
+        const args = [
+            'run',
+            '--name', name,
+            '-d', // Run in detached mode
+            '-w', workspace,
+            ...mounts,
+            ...extraArgs,
+            image,
+            ...cmd
+        ];
+
+        const result = spawnSync('docker', args, { stdio: 'pipe' });
+
+        return result.error == null && result.status === 0;
+    }
+
+    /**
+     * Stop the given container
+     * 
+     * @param name Container name
+     */
+    stopContainer(name: string): boolean {
+        const result = spawnSync('docker', ['stop', name], { stdio: 'pipe' });
+
+        return result.error == null && result.status === 0;
+    }
+
+    /**
+     * Returns the container logs (just one shot)
+     * 
+     * @param name Container name
+     */
+    logsContainer(name: string): string {
+        const result = spawnSync('docker', ['logs', name], {
+            stdio: 'pipe',
+            encoding: 'utf8'
+        });
+
+        if (result.error != null || result.status !== 0) {
+            return '';
+        }
+
+        // Combine stdout and stderr
+        const stdout = result.stdout || '';
+        const stderr = result.stderr || '';
+
+        return stdout + stderr;
+    }
+
+    /**
+     * Returns a process to follow the container logs
+     * 
+     * @param name Container name
+     */
+    logsFollowContainer(name: string): ChildProcessByStdio<null, Stream.Readable, Stream.Readable> {
+        // Start docker logs with follow flag
+        const logsProcess = spawn('docker', ['logs', '-f', name], {
+            stdio: ['ignore', 'pipe', 'pipe']
+        }) as ChildProcessByStdio<null, Stream.Readable, Stream.Readable>;
+
+        return logsProcess;
+    }
+
+    /**
+     * Clean up any existing container with the given name
+     * 
+     * @param name Container name
+     * @returns True when the docker command does not return any error
+     */
+    removeContainer(name: string): boolean {
+        const result = spawnSync('docker', ['rm', '-f', name], { stdio: 'pipe' });
+
+        return result.error == null;
+    }
+}

--- a/packages/cli/src/lib/iteration.ts
+++ b/packages/cli/src/lib/iteration.ts
@@ -1,0 +1,206 @@
+/**
+ * Define the iteration file that Rover will use to generate the setup script and 
+ * the prompts.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CURRENT_ITERATION_SCHEMA_VERSION = '1.0';
+export const ITERATION_FILENAME = 'iteration.json';
+
+export interface IterationConfigSchema {
+    // Schema version for migrations
+    version: string;
+
+    // The task ID
+    id: number;
+
+    // Iteration number from the task
+    iteration: number;
+
+    // Iteration title and description
+    title: string;
+    description: string;
+
+    // Timestamps
+    createdAt: string;  // ISO datetime string
+
+    // Previous iteration context
+    previousContext: {
+        plan?: string;      // Previous plan.md content
+        summary?: string;   // Previous summary.md content
+        iterationNumber?: number;  // Previous iteration number
+    };
+}
+
+/**
+ * Iteration configuration. It provides the agent with enough information to iterate over
+ * the given task.
+ */
+export class IterationConfig {
+    private data: IterationConfigSchema;
+    private filePath: string;
+
+    constructor(data: IterationConfigSchema, filePath: string) {
+        this.data = data;
+        this.filePath = filePath;
+        this.validate();
+    }
+
+    /**
+     * Create a new iteration config for the first iteration (from task command)
+     */
+    static createInitial(iterationPath: string, id: number, title: string, description: string): IterationConfig {
+        const schema: IterationConfigSchema = {
+            version: CURRENT_ITERATION_SCHEMA_VERSION,
+            id,
+            iteration: 1,
+            title: title,
+            description: description,
+            createdAt: new Date().toISOString(),
+            previousContext: {}  // Empty for first iteration
+        };
+
+        const filePath = join(iterationPath, ITERATION_FILENAME);
+        const instance = new IterationConfig(schema, filePath);
+        instance.save();
+        return instance;
+    }
+
+    /**
+     * Create a new iteration config for subsequent iterations (from iterate command)
+     */
+    static createIteration(
+        iterationPath: string,
+        iterationNumber: number,
+        id: number,
+        title: string,
+        description: string,
+        previousContext: { plan?: string; changes?: string; iterationNumber?: number }
+    ): IterationConfig {
+        const schema: IterationConfigSchema = {
+            version: CURRENT_ITERATION_SCHEMA_VERSION,
+            iteration: iterationNumber,
+            id,
+            title,
+            description,
+            createdAt: new Date().toISOString(),
+            previousContext
+        };
+
+        const filePath = join(iterationPath, ITERATION_FILENAME);
+        const instance = new IterationConfig(schema, filePath);
+        instance.save();
+        return instance;
+    }
+
+    /**
+     * Load an existing iteration config from disk
+     */
+    static load(iterationPath: string): IterationConfig {
+        const filePath = join(iterationPath, ITERATION_FILENAME);
+
+        if (!existsSync(filePath)) {
+            throw new Error(`Iteration config not found at ${filePath}`);
+        }
+
+        try {
+            const rawData = readFileSync(filePath, 'utf8');
+            const parsedData = JSON.parse(rawData);
+
+            // Migrate if necessary
+            const migratedData = IterationConfig.migrate(parsedData);
+
+            const instance = new IterationConfig(migratedData, filePath);
+
+            // If migration occurred, save the updated data
+            if (migratedData.version !== parsedData.version) {
+                instance.save();
+            }
+
+            return instance;
+        } catch (error) {
+            if (error instanceof SyntaxError) {
+                throw new Error(`Invalid JSON in iteration config: ${error.message}`);
+            }
+            throw new Error(`Failed to load iteration config: ${error}`);
+        }
+    }
+
+    /**
+     * Check if an iteration config exists
+     */
+    static exists(iterationPath: string): boolean {
+        const filePath = join(iterationPath, ITERATION_FILENAME);
+        return existsSync(filePath);
+    }
+
+
+    /**
+     * Migrate old config to current schema version
+     */
+    private static migrate(data: any): IterationConfigSchema {
+        // If already current version, return as-is
+        if (data.version === CURRENT_ITERATION_SCHEMA_VERSION) {
+            return data as IterationConfigSchema;
+        }
+
+        // For now, just return the data as-is since we're starting fresh
+        return data as IterationConfigSchema;
+    }
+
+    /**
+     * Save current data to disk
+     */
+    save(): void {
+        try {
+            this.validate();
+            const json = JSON.stringify(this.data, null, 2);
+            writeFileSync(this.filePath, json, 'utf8');
+        } catch (error) {
+            throw new Error(`Failed to save iteration config: ${error}`);
+        }
+    }
+
+    /**
+     * Validate the configuration data
+     */
+    private validate(): void {
+        const errors: string[] = [];
+
+        // Required fields
+        if (typeof this.data.version !== 'string') errors.push('version is required');
+        if (typeof this.data.iteration !== 'number') errors.push('iteration must be a number');
+        if (this.data.iteration < 1) errors.push('iteration must be at least 1');
+        if (typeof this.data.title !== 'string' || !this.data.title) errors.push('title is required');
+        if (typeof this.data.description !== 'string' || !this.data.description) errors.push('description is required');
+        if (!this.data.createdAt) errors.push('createdAt is required');
+
+        // Date validation
+        if (this.data.createdAt && isNaN(Date.parse(this.data.createdAt))) {
+            errors.push('createdAt must be a valid ISO date string');
+        }
+
+        if (errors.length > 0) {
+            throw new Error(`Iteration config validation error: ${errors.join(', ')}`);
+        }
+    }
+
+    // Data Access (Getters)
+    get version(): string { return this.data.version; }
+    get iteration(): number { return this.data.iteration; }
+    get title(): string { return this.data.title; }
+    get description(): string { return this.data.description; }
+    get createdAt(): string { return this.data.createdAt; }
+    get previousContext(): { plan?: string; summary?: string; iterationNumber?: number } {
+        return this.data.previousContext;
+    }
+
+    /**
+     * Get raw JSON data
+     */
+    toJSON(): IterationConfigSchema {
+        return { ...this.data };
+    }
+}

--- a/packages/cli/src/lib/prompt.ts
+++ b/packages/cli/src/lib/prompt.ts
@@ -1,4 +1,4 @@
-import { TaskDescription } from "./description.js";
+import { IterationConfig } from "./iteration.js";
 
 /***
  * This library provides the foundation to build prompts for different AI agents.
@@ -14,7 +14,7 @@ export class PromptBuilder {
     /**
      * Generate and save all prompt files to the specified directory
      */
-    generatePromptFiles(task: TaskDescription, promptsDir: string): void {
+    generatePromptFiles(iteration: IterationConfig, promptsDir: string): void {
         const { mkdirSync, writeFileSync } = require('node:fs');
         const { join } = require('node:path');
 
@@ -23,12 +23,12 @@ export class PromptBuilder {
 
         // Generate each prompt and save to file
         const prompts = {
-            'context.txt': this.context(task),
-            'plan.txt': this.plan(task),
-            'implement.txt': this.implement(task),
-            'review.txt': this.review(task),
-            'apply_review.txt': this.apply_review(task),
-            'summary.txt': this.summary(task)
+            'context.txt': this.context(iteration),
+            'plan.txt': this.plan(iteration),
+            'implement.txt': this.implement(iteration),
+            'review.txt': this.review(iteration),
+            'apply_review.txt': this.apply_review(iteration),
+            'summary.txt': this.summary(iteration)
         };
 
         // Write each prompt to its respective file
@@ -41,14 +41,14 @@ export class PromptBuilder {
     /**
      * Provides a prompt that fetches the context to build a task.
      */
-    context(task: TaskDescription): string {
+    context(iteration: IterationConfig): string {
         return `
 You are preparing a technical analysis for this task implementation. Your goal is to gather preliminary research that will help another engineer plan and implement the task effectively.
 
 Task to analyze:
-Title: ${task.title}
+Title: ${iteration.title}
 Description:
-${task.description}
+${iteration.description}
 
 Your analysis should:
 1. Identify files that will be edited or affected by this task
@@ -143,14 +143,14 @@ Example output:
     /**
      * Provides a prompt to define a plan for a task
      */
-    plan(task: TaskDescription): string {
+    plan(iteration: IterationConfig): string {
         return `
 You are preparing an implementation plan for this task. Your goal is to create a clear, actionable plan that another engineer can follow to complete the implementation.
 
 Task to plan:
-Title: ${task.title}
+Title: ${iteration.title}
 Description:
-${task.description}
+${iteration.description}
 
 Your plan should:
 1. Define a clear objective for what will be accomplished
@@ -192,14 +192,14 @@ Reference the context.md file for technical details. Write your plan to plan.md 
     /**
      * Provides a prompt to implement the plan
      */
-    implement(task: TaskDescription): string {
+    implement(iteration: IterationConfig): string {
         return `
 You are implementing this task following the established plan. Your goal is to complete the implementation according to the plan specifications.
 
 Task to implement:
-Title: ${task.title}
+Title: ${iteration.title}
 Description:
-${task.description}
+${iteration.description}
 
 Your implementation should:
 
@@ -317,14 +317,14 @@ Implemented GitHub issue fetching functionality for the task command. Added a ne
     /**
      * Provides a prompt to review task changes
      */
-    review(task: TaskDescription): string {
+    review(iteration: IterationConfig): string {
         return `
 You are acting as a senior code reviewer examining the implementation of this task. Your goal is to ensure the implementation follows the original plan, maintains code quality, and identifies any issues that need to be addressed.
 
 Task reviewed:
-Title: ${task.title}
+Title: ${iteration.title}
 Description:
-${task.description}
+${iteration.description}
 
 Your review should:
 1. Compare the implementation against the original plan.md to identify deviations
@@ -435,14 +435,14 @@ Begin your review by examining plan.md, changes.md, and the actual code changes.
     /**
      * Provides a prompt to apply review feedback and fix identified issues
      */
-    apply_review(task: TaskDescription): string {
+    apply_review(iteration: IterationConfig): string {
         return `
 You are implementing fixes based on the code review feedback. Your goal is to address all the issues identified in review.md and update the implementation accordingly.
 
 Task being fixed:
-Title: ${task.title}
+Title: ${iteration.title}
 Description:
-${task.description}
+${iteration.description}
 
 Your implementation should:
 1. Read and understand all issues listed in review.md
@@ -502,16 +502,16 @@ Start by examining review.md to understand all the issues that need to be addres
     /**
      * Provides a prompt to elaborate a summary
      */
-    summary(task: TaskDescription): string {
+    summary(iteration: IterationConfig): string {
         return `
 You are creating a summary of the implemented changes for this task. Your goal is to document what was accomplished and provide key information for future reference.
 
 Check the context.md and changes.md file to gather information.
 
 Task completed:
-Title: ${task.title}
+Title: ${iteration.title}
 Description:
-${task.description}
+${iteration.description}
 
 Your summary should:
 1. Describe what was implemented in 1-2 sentences

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -483,14 +483,16 @@ write_status "initializing" "Starting task" 5
 
 # Read task data from mounted JSON file
 TASK_ID=$(jq -r '.id' /task/description.json)
+TASK_ITERATION=$(jq -r '.iteration' /task/description.json)
 TASK_TITLE=$(jq -r '.title' /task/description.json)
 TASK_DESCRIPTION=$(jq -r '.description' /task/description.json)
 
 echo "======================================="
 echo "🚀 Rover Task Execution Setup (${this.agent})"
 echo "======================================="
-echo "Task ID: $TASK_ID"
 echo "Task Title: $TASK_TITLE"
+echo "Task ID: $TASK_ID"
+echo "Task Iteration: $TASK_ITERATION"
 echo "======================================="
 
 write_status "initializing" "Load metadata" 5

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -39,6 +39,7 @@ export interface Environment {
 
 export interface AIProvider {
     expandTask(briefDescription: string, projectPath: string): Promise<TaskExpansion | null>;
+    expandIterationInstructions(instructions: string, previousPlan?: string, previousChanges?: string): Promise<TaskExpansion | null>;
     generateCommitMessage(taskTitle: string, taskDescription: string, recentCommits: string[], summaries: string[]): Promise<string | null>
     resolveMergeConflicts(filePath: string, diffContext: string, conflictedContent: string): Promise<string | null>
 }

--- a/packages/cli/src/utils/ai-claude.ts
+++ b/packages/cli/src/utils/ai-claude.ts
@@ -88,6 +88,67 @@ Examples:
         }
     }
 
+    async expandIterationInstructions(instructions: string, previousPlan?: string, previousChanges?: string): Promise<TaskExpansion | null> {
+        let contextSection = '';
+
+        if (previousPlan || previousChanges) {
+            contextSection += `\nPrevious iteration context:\n`;
+
+            if (previousPlan) {
+                contextSection += `\nPrevious Plan:\n${previousPlan}\n`;
+            }
+
+            if (previousChanges) {
+                contextSection += `\nPrevious Changes Made:\n${previousChanges}\n`;
+            }
+        }
+
+        const prompt = `You are helping iterate on a software development task. Based on new user instructions and previous iteration context, create a focused title and detailed description for this specific iteration.
+
+${contextSection}
+
+New user instructions for this iteration:
+${instructions}
+
+Create a clear, action-oriented title and comprehensive description that:
+1. Incorporates the new user instructions
+2. Builds upon the previous work (if any)
+3. Focuses on what needs to be accomplished in this specific iteration
+4. Is specific and actionable
+
+Respond ONLY with valid JSON in this exact format:
+{
+  "title": "Iteration-specific title focusing on the new requirements (max 12 words)",
+  "description": "Detailed description that explains what needs to be done in this iteration, building on previous work. Include specific steps, requirements, and context from previous iterations. (3-5 sentences)"
+}
+
+Examples:
+- Instructions: "add error handling to the login form"
+  Previous: User login form was implemented
+  Response: {"title": "Add comprehensive error handling to login form", "description": "Enhance the existing login form by implementing comprehensive error handling for various failure scenarios. Add validation for network errors, authentication failures, and form validation errors. Display user-friendly error messages and ensure proper error state management. This builds on the previously implemented basic login form functionality."}
+
+- Instructions: "improve the performance of the search feature"
+  Previous: Search functionality was added
+  Response: {"title": "Optimize search performance and add caching", "description": "Improve the performance of the existing search feature by implementing result caching, debounced input handling, and optimized database queries. Add loading states and pagination to handle large result sets efficiently. This enhancement builds on the previously implemented basic search functionality to provide a better user experience."}`;
+
+        try {
+            const response = await ClaudeAI.invoke(prompt, true);
+
+            // Extract JSON from response
+            const jsonMatch = response.match(/\{[\s\S]*\}/);
+            if (!jsonMatch) {
+                throw new Error('No JSON found in response');
+            }
+
+            const { result } = JSON.parse(jsonMatch[0]);
+            const expansion = JSON.parse(result.replace('```json', '').replace('```', ''));
+            return expansion as TaskExpansion;
+        } catch (error) {
+            console.error('Failed to expand iteration instructions with Claude:', error);
+            return null;
+        }
+    }
+
     async generateCommitMessage(taskTitle: string, taskDescription: string, recentCommits: string[], summaries: string[]): Promise<string | null> {
         try {
             let prompt = `You are a git commit message generator. Generate a concise, clear commit message for the following task completion.

--- a/packages/cli/src/utils/gemini.ts
+++ b/packages/cli/src/utils/gemini.ts
@@ -75,6 +75,61 @@ Examples:
         }
     }
 
+    async expandIterationInstructions(instructions: string, previousPlan?: string, previousChanges?: string): Promise<TaskExpansion | null> {
+        let contextSection = '';
+
+        if (previousPlan || previousChanges) {
+            contextSection += `\nPrevious iteration context:\n`;
+
+            if (previousPlan) {
+                contextSection += `\nPrevious Plan:\n${previousPlan}\n`;
+            }
+
+            if (previousChanges) {
+                contextSection += `\nPrevious Changes Made:\n${previousChanges}\n`;
+            }
+        }
+
+        const prompt = `You are helping iterate on a software development task. Based on new user instructions and previous iteration context, create a focused title and detailed description for this specific iteration.
+
+${contextSection}
+
+New user instructions for this iteration:
+${instructions}
+
+Create a clear, action-oriented title and comprehensive description that:
+1. Incorporates the new user instructions
+2. Builds upon the previous work (if any)
+3. Focuses on what needs to be accomplished in this specific iteration
+4. Is specific and actionable
+
+Respond ONLY with valid JSON in this exact format:
+{
+  "title": "Iteration-specific title focusing on the new requirements (max 12 words)",
+  "description": "Detailed description that explains what needs to be done in this iteration, building on previous work. Include specific steps, requirements, and context from previous iterations. (3-5 sentences)"
+}
+
+Examples:
+- Instructions: "add error handling to the login form"
+  Previous: User login form was implemented
+  Response: {"title": "Add comprehensive error handling to login form", "description": "Enhance the existing login form by implementing comprehensive error handling for various failure scenarios. Add validation for network errors, authentication failures, and form validation errors. Display user-friendly error messages and ensure proper error state management. This builds on the previously implemented basic login form functionality."}
+
+- Instructions: "improve the performance of the search feature"
+  Previous: Search functionality was added
+  Response: {"title": "Optimize search performance and add caching", "description": "Improve the performance of the existing search feature by implementing result caching, debounced input handling, and optimized database queries. Add loading states and pagination to handle large result sets efficiently. This enhancement builds on the previously implemented basic search functionality to provide a better user experience."}`;
+
+        try {
+            const response = await GeminiAI.invoke(prompt, true);
+            // Gemini returns plain JSON without wrapper
+            const parsed = response.replace('```json', '').replace('```', '').trim();
+            const expansion = JSON.parse(parsed);
+            return expansion as TaskExpansion;
+        } catch (error) {
+            console.error('Failed to expand iteration instructions with Gemini:', error);
+            return null;
+        }
+    }
+
     async generateCommitMessage(taskTitle: string, taskDescription: string, recentCommits: string[], summaries: string[]): Promise<string | null> {
         try {
             let prompt = `You are a git commit message generator. Generate a concise, clear commit message for the following task completion.

--- a/packages/cli/src/utils/task-status.ts
+++ b/packages/cli/src/utils/task-status.ts
@@ -11,6 +11,8 @@ export const formatTaskStatus = (status: string): string => {
             return 'In Progress';
         case 'COMPLETED':
             return 'Completed';
+        case 'RUNNING':
+            return 'Running';
         case 'FAILED':
             return 'Failed';
         case 'ITERATING':
@@ -28,6 +30,8 @@ export const statusColor = (status: string): StyleFunction => {
             return colors.yellow;
         case 'COMPLETED':
             return colors.green;
+        case 'RUNNING':
+            return colors.cyan;
         case 'ITERATING':
             return colors.magenta;
         case 'FAILED':


### PR DESCRIPTION
Update the iteration and task creation process to rely on a single `iteration.json` file. Before, the task and iteration were relying on different files, causing inconsistencies in different commands. Now, we only have two different files:

- `description.json`: task original title, description, timestamps and global status.
- `iteration.json`: iteration specific title and description.

I also improved the task expansion for iterations, asking the agent to generate specific instructions based on the plan and changes files from the previous iteration.

Closes #54 

## Changes

- Remove existing `iteration-metadata.json` and `iteration.json` files.
- Create a new `IterationConfig` with a fixed and tracked schema
- Use it when creating and iterating tasks
- Add a new docker class I will use after #55 is closed
- Add a new prompt for AI agents to improve instructions based on previous context