### PR TITLE
chore: `updateIteration` only bumps `lastIterationAt` from task descr…

### DIFF
--- a/packages/cli/src/lib/description.ts
+++ b/packages/cli/src/lib/description.ts
@@ -375,12 +375,6 @@ export class TaskDescription {
      * Update iteration metadata
      */
     updateIteration(metadata: IterationMetadata): void {
-        if (metadata.title) {
-            this.data.title = metadata.title;
-        }
-        if (metadata.description) {
-            this.data.description = metadata.description;
-        }
         if (metadata.timestamp) {
             this.data.lastIterationAt = metadata.timestamp;
         }


### PR DESCRIPTION
## Summary

Refactors the `updateIteration` method in `TaskDescription` class to only update the `lastIterationAt` timestamp field, removing the logic that previously updated the task's title and description.

## Changes

- **Modified**: `packages/cli/src/lib/description.ts`
  - Removed code that updates `this.data.title` and `this.data.description` from iteration metadata
  - Kept only the `lastIterationAt` timestamp update logic
  - Simplified the method by removing 6 lines of unnecessary update logic

## Motivation

This change ensures that the `updateIteration` method has a single, clear responsibility: tracking when the last iteration occurred. Task title and description updates should be handled through other methods, keeping the iteration tracking focused and predictable.

🤖 Generated with [Claude Code](https://claude.ai/code)