### PR TITLE
chore: improve jq installation logging to avoid output conflicts

### DIFF
--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -443,9 +443,9 @@ check_command() {
 ensure_jq() {
     if ! check_command jq; then
         echo "📦 Installing jq for JSON parsing..."
-        write_status "initializing" "Installing jq for JSON parsing" 5
-        apk add --no-cache jq
-        if [ $? -ne 0 ]; then
+        if apk add --no-cache jq; then
+            write_status "initializing" "Installed jq for JSON parsing" 5
+        else
             echo "❌ Failed to install jq"
             safe_exit 1 "apk add jq failed"
         fi


### PR DESCRIPTION
Fix circular dependency where status logging attempted to use jq while jq was being installed.

## Changes

- Moved status logging to occur after successful jq installation
- Prevents "command not found" errors during jq installation process

Closes: https://github.com/endorhq/rover/issues/40