### PR TITLE
fix: ensure open workspace works by adding missing suffix in fallbacks

### DIFF
--- a/packages/extension/src/rover/cli.mts
+++ b/packages/extension/src/rover/cli.mts
@@ -207,11 +207,11 @@ export class RoverCLI {
 
             // Fallback: construct expected path
             const workspaceRoot = this.workspaceRoot || process.cwd();
-            return `${workspaceRoot}/.rover/tasks/${taskId}`;
+            return `${workspaceRoot}/.rover/tasks/${taskId}/workspace`;
         } catch (error) {
             // Fallback: construct expected path
             const workspaceRoot = this.workspaceRoot || process.cwd();
-            return `${workspaceRoot}/.rover/tasks/${taskId}`;
+            return `${workspaceRoot}/.rover/tasks/${taskId}/workspace`;
         }
     }
 


### PR DESCRIPTION
Fix the fallback paths in the VS Code extension's task workspace resolution to properly include the `/workspace` suffix, ensuring the open workspace functionality works correctly.

The issue occurred when the CLI failed to return task details, causing the extension to use fallback paths that were missing the required `/workspace` subdirectory suffix.

Closes #114 

## Changes

- Updated both fallback path constructions in `getTaskWorkspacePath()` method to include `/workspace` suffix
- Ensures consistency between successful CLI responses and fallback behavior
- Fixes workspace opening functionality when CLI calls fail

## Notes

This was a simple but critical fix to maintain consistency in workspace path resolution across different code paths in the extension.