### PR TITLE
feat: allow setting custom target branch name when creating tasks

### DIFF
--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -514,14 +514,14 @@ export const startDockerExecution = async (
         if (!jsonMode) {
           showTips([
             'Use ' +
-            colors.cyan(`rover logs -f ${task.id}`) +
-            ` to monitor logs`,
+              colors.cyan(`rover logs -f ${task.id}`) +
+              ` to monitor logs`,
             'Use ' +
-            colors.cyan(`rover inspect ${task.id}`) +
-            ` to get task details`,
+              colors.cyan(`rover inspect ${task.id}`) +
+              ` to get task details`,
             'Use ' +
-            colors.cyan(`rover list`) +
-            ` to check the status of all tasks`,
+              colors.cyan(`rover list`) +
+              ` to check the status of all tasks`,
           ]);
         }
 
@@ -563,8 +563,8 @@ export const startDockerExecution = async (
           console.log(colors.gray('  Resetting the task status to "New"'));
           console.log(
             colors.gray('  Use ') +
-            colors.cyan(`rover start ${taskId}`) +
-            colors.gray(' to retry execution')
+              colors.cyan(`rover start ${taskId}`) +
+              colors.gray(' to retry execution')
           );
         }
 
@@ -594,8 +594,8 @@ export const startDockerExecution = async (
       console.log(colors.yellow('⚠ Task reset to NEW status'));
       console.log(
         colors.gray('  Use ') +
-        colors.cyan(`rover start ${taskId}`) +
-        colors.gray(' to retry execution')
+          colors.cyan(`rover start ${taskId}`) +
+          colors.gray(' to retry execution')
       );
     }
 
@@ -789,7 +789,8 @@ export const taskCommand = async (
 ) => {
   const telemetry = getTelemetry();
   // Extract options
-  const { follow, yes, json, fromGithub, debug, sourceBranch, targetBranch } = options;
+  const { follow, yes, json, fromGithub, debug, sourceBranch, targetBranch } =
+    options;
 
   // Check if rover is initialized
   const roverPath = join(process.cwd(), '.rover');
@@ -798,8 +799,8 @@ export const taskCommand = async (
       console.log(colors.red('✗ Rover is not initialized in this directory'));
       console.log(
         colors.gray('  Run ') +
-        colors.cyan('rover init') +
-        colors.gray(' first')
+          colors.cyan('rover init') +
+          colors.gray(' first')
       );
     }
     // TODO: use exitWithError
@@ -866,10 +867,10 @@ export const taskCommand = async (
         console.log(colors.gray('├── Title: ') + colors.cyan(issueData.title));
         console.log(
           colors.gray('└── Body: ') +
-          colors.white(
-            issueData.body.substring(0, 100) +
-            (issueData.body.length > 100 ? '...' : '')
-          )
+            colors.white(
+              issueData.body.substring(0, 100) +
+                (issueData.body.length > 100 ? '...' : '')
+            )
         );
       }
     } else {
@@ -914,13 +915,13 @@ export const taskCommand = async (
         if (initialPrompt.length > 0) {
           console.log(
             colors.gray(`  Example: `) +
-            colors.cyan(`rover task --source-branch main "${initialPrompt}"
+              colors.cyan(`rover task --source-branch main "${initialPrompt}"
 `)
           );
         } else {
           console.log(
             colors.gray(`  Example: `) +
-            colors.cyan(`rover task --source-branch main
+              colors.cyan(`rover task --source-branch main
 `)
           );
         }
@@ -993,8 +994,8 @@ export const taskCommand = async (
     // Expand task with selected AI provider
     const spinner = !json
       ? yoctoSpinner({
-        text: `Expanding task description with ${selectedAiAgent.charAt(0).toUpperCase() + selectedAiAgent.slice(1)}...`,
-      }).start()
+          text: `Expanding task description with ${selectedAiAgent.charAt(0).toUpperCase() + selectedAiAgent.slice(1)}...`,
+        }).start()
       : null;
 
     try {
@@ -1020,7 +1021,7 @@ export const taskCommand = async (
             );
             console.log(
               colors.gray('└── Description: ') +
-              colors.white(taskData.description)
+                colors.white(taskData.description)
             );
           }
 
@@ -1197,8 +1198,8 @@ export const taskCommand = async (
         );
         console.log(
           colors.gray('  Use ') +
-          colors.cyan(`rover start ${taskId}`) +
-          colors.gray(' to retry execution')
+            colors.cyan(`rover start ${taskId}`) +
+            colors.gray(' to retry execution')
         );
       }
       throw error;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -45,8 +45,8 @@ program
       showTips(
         [
           'Run ' +
-          colors.cyan('rover init') +
-          ' in this directory to initialize project config and user settings',
+            colors.cyan('rover init') +
+            ' in this directory to initialize project config and user settings',
         ],
         {
           title: TIP_TITLES.NEXT_STEPS,
@@ -76,8 +76,8 @@ program
       showTips(
         [
           'Run ' +
-          colors.cyan('rover init') +
-          ' in this directory to initialize user settings',
+            colors.cyan('rover init') +
+            ' in this directory to initialize user settings',
         ],
         {
           title: TIP_TITLES.NEXT_STEPS,
@@ -118,7 +118,10 @@ program
   )
   .option('-f, --follow', 'Follow execution logs in real-time')
   .option('-y, --yes', 'Skip all confirmations and run non-interactively')
-  .option('-s, --source-branch <branch>', 'Base branch for git worktree creation')
+  .option(
+    '-s, --source-branch <branch>',
+    'Base branch for git worktree creation'
+  )
   .option('-t, --target-branch <branch>', 'Custom name for the worktree branch')
   .option('--json', 'Output the result in JSON format')
   .option('--debug', 'Show debug information like running commands')


### PR DESCRIPTION
Adds the ability to specify a custom branch name when creating a new task, providing more control over git branch naming conventions. This change also clarifies the branch selection options by renaming the existing `--branch` flag to `--source-branch`.

Closes #128

## Changes

- Added `--target-branch` option to specify a custom name for the worktree branch instead of auto-generated names
- Renamed `--branch` option to `--source-branch` for clarity about its purpose as the base branch
- Updated branch validation logic to use the new option names
- Fixed formatting inconsistencies in string concatenations throughout the file

## Notes

The auto-generated branch naming pattern (`rover/task-{id}-{randomString}`) is still used by default when no custom target branch is specified. This maintains backward compatibility while giving users the flexibility to use their own branch naming conventions when needed.