### PR TITLE
feat: copy .env* files to the workspace for development

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -59,8 +59,8 @@ export const startCommand = async (
       exitWithError(jsonOutput, json, {
         tips: [
           'Use ' +
-          colors.cyan(`rover task "${task.title}"`) +
-          colors.gray(' to create a new task'),
+            colors.cyan(`rover task "${task.title}"`) +
+            colors.gray(' to create a new task'),
         ],
       });
       return;
@@ -114,7 +114,7 @@ export const startCommand = async (
         git.createWorktree(worktreePath, branchName);
 
         // Copy user .env development files
-        copyEnvironmentFiles(process.cwd(), worktreePath)
+        copyEnvironmentFiles(process.cwd(), worktreePath);
 
         // Update task with workspace information
         task.setWorkspace(worktreePath, branchName);

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -479,14 +479,14 @@ export const startDockerExecution = async (
         if (!jsonMode) {
           showTips([
             'Use ' +
-            colors.cyan(`rover logs -f ${task.id}`) +
-            ` to monitor logs`,
+              colors.cyan(`rover logs -f ${task.id}`) +
+              ` to monitor logs`,
             'Use ' +
-            colors.cyan(`rover inspect ${task.id}`) +
-            ` to get task details`,
+              colors.cyan(`rover inspect ${task.id}`) +
+              ` to get task details`,
             'Use ' +
-            colors.cyan(`rover list`) +
-            ` to check the status of all tasks`,
+              colors.cyan(`rover list`) +
+              ` to check the status of all tasks`,
           ]);
         }
 
@@ -528,8 +528,8 @@ export const startDockerExecution = async (
           console.log(colors.gray('  Resetting the task status to "New"'));
           console.log(
             colors.gray('  Use ') +
-            colors.cyan(`rover start ${taskId}`) +
-            colors.gray(' to retry execution')
+              colors.cyan(`rover start ${taskId}`) +
+              colors.gray(' to retry execution')
           );
         }
 
@@ -559,8 +559,8 @@ export const startDockerExecution = async (
       console.log(colors.yellow('⚠ Task reset to NEW status'));
       console.log(
         colors.gray('  Use ') +
-        colors.cyan(`rover start ${taskId}`) +
-        colors.gray(' to retry execution')
+          colors.cyan(`rover start ${taskId}`) +
+          colors.gray(' to retry execution')
       );
     }
 
@@ -682,10 +682,10 @@ export const taskCommand = async (
           );
           console.log(
             colors.gray('└── Body: ') +
-            colors.white(
-              issueData.body.substring(0, 100) +
-              (issueData.body.length > 100 ? '...' : '')
-            )
+              colors.white(
+                issueData.body.substring(0, 100) +
+                  (issueData.body.length > 100 ? '...' : '')
+              )
           );
         }
       } else {
@@ -737,13 +737,13 @@ export const taskCommand = async (
         if (initialPrompt.length > 0) {
           console.log(
             colors.gray(`  Example: `) +
-            colors.cyan(`rover task --source-branch main "${initialPrompt}"
+              colors.cyan(`rover task --source-branch main "${initialPrompt}"
 `)
           );
         } else {
           console.log(
             colors.gray(`  Example: `) +
-            colors.cyan(`rover task --source-branch main
+              colors.cyan(`rover task --source-branch main
 `)
           );
         }
@@ -782,7 +782,7 @@ export const taskCommand = async (
         exitWithError(jsonOutput, json, {
           tips: [
             'Provide a description as an argument using' +
-            colors.cyan(' rover task "your task description" --yes'),
+              colors.cyan(' rover task "your task description" --yes'),
           ],
         });
         return;
@@ -813,8 +813,8 @@ export const taskCommand = async (
     // Expand task with selected AI provider
     const spinner = !json
       ? yoctoSpinner({
-        text: `Expanding task description with ${selectedAiAgent.charAt(0).toUpperCase() + selectedAiAgent.slice(1)}...`,
-      }).start()
+          text: `Expanding task description with ${selectedAiAgent.charAt(0).toUpperCase() + selectedAiAgent.slice(1)}...`,
+        }).start()
       : null;
 
     try {
@@ -840,7 +840,7 @@ export const taskCommand = async (
             );
             console.log(
               colors.gray('└── Description: ') +
-              colors.white(taskData.description)
+                colors.white(taskData.description)
             );
           }
 
@@ -1044,11 +1044,11 @@ export const taskCommand = async (
       tips: [
         'Use ' + colors.cyan('rover list') + ' to check the list of tasks',
         'Use ' +
-        colors.cyan(`rover logs -f ${task.id}`) +
-        ' to watch the task logs',
+          colors.cyan(`rover logs -f ${task.id}`) +
+          ' to watch the task logs',
         'Use ' +
-        colors.cyan(`rover inspect ${task.id}`) +
-        ' to check the task status',
+          colors.cyan(`rover inspect ${task.id}`) +
+          ' to check the task status',
       ],
     });
   } else {

--- a/packages/cli/src/utils/env-files.ts
+++ b/packages/cli/src/utils/env-files.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 /**
  * Copy environment files from source directory to target directory
  * Copies .env, .env.*, but excludes .env.example
- * 
+ *
  * @param sourcePath - Source directory path
  * @param targetPath - Target directory path
  * @param jsonMode - Whether to suppress console output
@@ -28,9 +28,8 @@ export const copyEnvironmentFiles = (
 
     // Find and copy .env.* files (but not .env.example)
     const files = readdirSync(sourcePath);
-    const envFiles = files.filter(file =>
-      file.startsWith('.env.') &&
-      file !== '.env.example'
+    const envFiles = files.filter(
+      file => file.startsWith('.env.') && file !== '.env.example'
     );
 
     for (const envFile of envFiles) {


### PR DESCRIPTION
Automatically copy development environment files to new worktrees during task creation. This ensures developers have the necessary environment configuration files in their isolated task workspaces without manual intervention.

## Changes

- Added `copyEnvironmentFiles()` utility to copy `.env` and `.env.*` files (excluding `.env.example`) from source to target directories
- Integrated environment file copying into `task` command after worktree creation
- Integrated environment file copying into `start` command when creating worktrees for existing tasks
- Ensures gitignored development configuration files are available in new task workspaces

## Notes

This enhancement addresses the common pain point where developers need to manually copy environment files to each new worktree. The implementation intelligently excludes `.env.example` files since they're typically tracked in git and serve as templates rather than actual configuration.

Closes #129