### PR TITLE
fix: handle case-insensitive status values in list command

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -165,7 +165,9 @@ export const listCommand = async (
         status,
         taskData,
         attribute: 'status',
-      });
+      })
+        .toString()
+        .toLowerCase();
       const startedAt = lastIterationOrTaskProperty({
         status,
         taskData,

--- a/packages/cli/src/utils/status.ts
+++ b/packages/cli/src/utils/status.ts
@@ -106,7 +106,7 @@ export const getAllTaskStatuses = (): {
         // Ignore task data read errors
       }
 
-      if (['MERGED', 'PUSHED'].includes(taskData?.status)) {
+      if (['MERGED', 'PUSHED', 'COMPLETED'].includes(taskData?.status)) {
         latestStatus = taskData.status;
       } else {
         if (existsSync(iterationsPath)) {


### PR DESCRIPTION
Fix the list command to properly handle case-insensitive status values by converting them to lowercase before processing. Also adds support for the COMPLETED status when checking task data.

Closes #149

## Changes

- Convert status values to lowercase in the list command to ensure consistent processing
- Add COMPLETED to the list of valid task statuses alongside MERGED and PUSHED
- Ensure status string conversion with explicit `toString()` before applying lowercase

## Notes

This is a temporary fix to address issues with status values that may have different casing. A more comprehensive solution might involve normalizing all status values at the data layer.