### PR TITLE
chore: do not throw when commands have exit code other than 0

### DIFF
--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -53,14 +53,6 @@ const validations = (
 
     // Check if git repository has at least one commit
     if (!git.hasCommits()) {
-      if (!isJsonMode) {
-        console.log(colors.red('✗ No commits found in git repository'));
-        console.log(
-          colors.gray(
-            '  Git worktree requires at least one commit in the repository'
-          )
-        );
-      }
       return {
         error: 'No commits found in git repository',
         tips: ['Git worktree requires at least one commit in the repository'],


### PR DESCRIPTION
Improve git command error handling across the codebase by adding the `reject: false` option to prevent throwing errors and remove duplicate console output from task validation.

This change makes git operations more resilient by handling errors gracefully instead of throwing exceptions, and eliminates redundant error messages shown to users.

## Changes

- Added `reject: false` option to all `launchSync` git commands in `packages/common/src/git.ts` to prevent throwing on non-zero exit codes
- Removed duplicate console output for "no commits found" error in `packages/cli/src/commands/task.ts` 
- Fixed git availability check comment from "docker" to "git" in Git constructor
- Improved error handling consistency across git operations like `isGitRepo()`, `getRepositoryRoot()`, `hasCommits()`, `branchExists()`, and `createWorktree()`

## Notes

The `reject: false` option allows git commands to return exit codes without throwing exceptions, enabling proper error handling through exit code checking rather than try/catch blocks. This approach provides better control over error scenarios and reduces unexpected crashes.

Closes #151