### PR TITLE
chore: make git a global precondition

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Then, run `rover task` to create a task describing what you want to accomplish a
 
 ![A screencast showing rover task](https://github.com/user-attachments/assets/e7bbfa18-dd75-4b15-9f2b-50b0be53cdad)
 
-
 Rover will:
 
 - 🔒 Prepare a **local isolated environment** (using containers) with an independent copy of your project code

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -40,33 +40,6 @@ const validations = (
   selectedAiAgent?: string,
   isJsonMode?: boolean
 ): validationResult => {
-  // Check if we're in a git repository
-  try {
-    const git = new Git();
-
-    if (!git.isGitRepo()) {
-      return {
-        error: 'Not in a git repository',
-        tips: ['Rover requires the project to be in a git repository'],
-      };
-    }
-
-    // Check if git repository has at least one commit
-    if (!git.hasCommits()) {
-      return {
-        error: 'No commits found in git repository',
-        tips: ['Git worktree requires at least one commit in the repository'],
-      };
-    }
-  } catch (error) {
-    return {
-      error: 'Git repository validation failed',
-      tips: [
-        'Please ensure git is installed and the repository is properly initialized',
-      ],
-    };
-  }
-
   // Check AI agent credentials based on selected agent
   if (selectedAiAgent === 'claude') {
     const claudeFile = join(homedir(), '.claude.json');

--- a/packages/common/src/git.ts
+++ b/packages/common/src/git.ts
@@ -49,11 +49,8 @@ export type GitRemoteUrlOptions = {
  * A class to manage and run docker commands
  */
 export class Git {
-  constructor() {
-    // Check git is available
-    if (launchSync('git', ['--version'], { reject: false }).exitCode !== 0) {
-      throw new GitError('Git is not installed.');
-    }
+  version(): string {
+    return launchSync('git', ['--version']).stdout?.toString() || 'unknown';
   }
 
   isGitRepo(): boolean {


### PR DESCRIPTION
Refactor git availability checks to be performed globally at the CLI entry point rather than within individual commands, improving consistency and reducing code duplication across the codebase.

Previously, each command had to individually validate git availability and repository status. This change centralizes these checks using Commander.js preAction hooks, ensuring all commands have the required git environment before execution.

## Changes

- Added global preAction hook in CLI entry point to validate git installation and repository status
- Removed git availability check from Git class constructor to avoid throwing errors during instantiation  
- Removed individual git validations from task command since they're now handled globally
- Added `version()` method to Git class to check git availability without throwing
- Improved error messages with actionable tips for users

## Notes

This architectural change ensures that all Rover commands have consistent git requirements and clearer error messaging when git prerequisites are not met.