### PR TITLE
fix: properly build extension when using esm

### DIFF
--- a/packages/extension/esbuild.mjs
+++ b/packages/extension/esbuild.mjs
@@ -151,13 +151,6 @@ async function main() {
     await Promise.all([extensionCtx.rebuild(), webviewCtx.rebuild()]);
     await Promise.all([extensionCtx.dispose(), webviewCtx.dispose()]);
   }
-
-  // if (watch) {
-  //   await Promise.all([extensionCtx.watch()]);
-  // } else {
-  //   await Promise.all([extensionCtx.rebuild()]);
-  //   await Promise.all([extensionCtx.dispose()]);
-  // }
 }
 
 main().catch(e => {


### PR DESCRIPTION
I found that extension build process was failing. The process was success, but the output was not working on VSCode due to an `undefined` value. The root cause was mixing ESM modules in a CJS output. After removing the `silent` logLevel in esbuild, I got the following warning:

```
❯ node esbuild.mjs
[watch] build started
▲ [WARNING] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]

    ../common/dist/index.js:1:1663:
      1 │ ...n,`default`,{value:e,enumerable:!0}):n,e)),k=e(import.meta.url);function A(e){if(typeof e!=`object`||!e)...
        ╵                                                   ~~~~~~~~~~~

  You need to set the output format to "esm" for "import.meta" to work correctly.

[copy-codicons] Codicon CSS copied to /home/angel/Workspace/rover/packages/extension/dist/codicons/codicon.css
[copy-codicons] Codicon Font copied to /home/angel/Workspace/rover/packages/extension/dist/codicons/codicon.ttf
[watch] build finished
```

I forced a the definition using `esbuild` configuration.

Refs #156 