### PR TITLE
fix: avoid marking merged/pushed tasks as completed when updating status

### DIFF
--- a/packages/cli/src/lib/description.ts
+++ b/packages/cli/src/lib/description.ts
@@ -358,8 +358,6 @@ export class TaskDescription {
 
       switch (status.status) {
         case 'completed':
-        case 'merged':
-        case 'pushed':
           statusName = status.status.toUpperCase() as TaskStatus;
           timestamp = status.completedAt;
           break;
@@ -376,6 +374,14 @@ export class TaskDescription {
           statusName = 'IN_PROGRESS';
           timestamp = status.updatedAt;
           break;
+      }
+
+      // The merged / pushed status is already a completed state
+      if (
+        statusName === 'COMPLETED' &&
+        ['MERGED', 'PUSHED'].includes(this.status)
+      ) {
+        return;
       }
 
       const metadata = { timestamp, error };


### PR DESCRIPTION
Fix a bug where tasks with 'merged' or 'pushed' status would incorrectly be reset to 'completed' when updating their status from external sources.

Refs #156 

## Changes

- Modified `updateFromDescription()` method in `TaskDescription` class to preserve existing 'merged' and 'pushed' statuses
- Added a check to prevent status downgrade from 'merged'/'pushed' back to 'completed'
- Removed 'merged' and 'pushed' cases from the switch statement that sets status to 'COMPLETED'

## Notes

This ensures that once a task reaches 'merged' or 'pushed' status, it maintains that status instead of being reverted to the less specific 'completed' status during status updates.