### PR TITLE
chore: avoid duplicating tips when starting a container

### DIFF
--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -18,7 +18,7 @@ import { getTelemetry } from '../lib/telemetry.js';
 import { showRoverChat } from '../utils/display.js';
 import { readFromStdin, stdinIsAvailable } from '../utils/stdin.js';
 import { CLIJsonOutput } from '../types.js';
-import { exitWithError, exitWithWarn } from '../utils/exit.js';
+import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
 import { fa } from 'zod/locales';
 
 const { prompt } = enquirer;
@@ -446,9 +446,18 @@ export const iterateCommand = async (
     );
 
     result.success = true;
-    if (options.json) {
-      console.log(JSON.stringify(result, null, 2));
-    }
+
+    exitWithSuccess('Iteration started successfully', result, json, {
+      tips: [
+        'Use ' + colors.cyan('rover list') + ' to check the list of tasks',
+        'Use ' +
+          colors.cyan(`rover logs -f ${task.id}`) +
+          ' to watch the task logs',
+        'Use ' +
+          colors.cyan(`rover inspect ${task.id}`) +
+          ' to check the task status',
+      ],
+    });
   } catch (error) {
     if (error instanceof TaskNotFoundError) {
       result.error = error.message;

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -253,17 +253,6 @@ export const startDockerExecution = async (
         .trim();
 
       if (spinner) spinner.success('Container started in background');
-      if (!jsonMode) {
-        showTips([
-          'Use ' + colors.cyan(`rover logs -f ${task.id}`) + ` to monitor logs`,
-          'Use ' +
-            colors.cyan(`rover inspect ${task.id}`) +
-            ` to get task details`,
-          'Use ' +
-            colors.cyan(`rover list`) +
-            ` to check the status of all tasks`,
-        ]);
-      }
 
       // Update task metadata with container ID
       updateTaskMetadata(


### PR DESCRIPTION
Consolidate tip messages to avoid duplication when starting task containers. Previously, tips were displayed both in the task command and iterate command, leading to redundant output.

## Changes

- Moved tip display logic from `startDockerExecution()` in task.ts to the iterate command
- Added comprehensive tips to `exitWithSuccess()` call in iterate command showing how to monitor and inspect tasks
- Removed duplicate tip messages from the docker execution flow to ensure tips are only shown once
- Ensured consistent tip formatting across both task creation and iteration flows

## Notes

This improves the user experience by displaying helpful tips only once at the appropriate time, reducing visual clutter in the terminal output while still providing users with the necessary commands to monitor their tasks.