### PR TITLE
chore: prevent logging of sensitive command output

### DIFF
--- a/packages/cli/src/lib/agents/claude.ts
+++ b/packages/cli/src/lib/agents/claude.ts
@@ -11,12 +11,11 @@ import { join } from 'node:path';
 import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 
 const findKeychainCredentials = (key: string): string => {
-  const result = launchSync('security', [
-    'find-generic-password',
-    '-s',
-    key,
-    '-w',
-  ]);
+  const result = launchSync(
+    'security',
+    ['find-generic-password', '-s', key, '-w'],
+    { mightLogSensitiveInformation: true }
+  );
   return result.stdout?.toString() || '';
 };
 


### PR DESCRIPTION
Add security protection to prevent logging of sensitive command output, specifically for commands that might contain credentials or API keys.

This change introduces a new option to mark commands that might produce sensitive output, ensuring that such output is redacted from logs while preserving the command's functionality.

## Changes

- Added `mightLogSensitiveInformation` option to `LaunchOptions` and `LaunchSyncOptions` types
- Modified logging functions to redact output when sensitive information flag is set
- Updated keychain credential retrieval in Claude agent to use the new secure logging option
- Sensitive output is replaced with `**** redacted output ****` in logs when the flag is enabled

## Notes

This security enhancement ensures that credentials retrieved from system keychain or other sensitive command outputs are not inadvertently logged in verbose mode, preventing potential credential exposure in log files.

Closes https://github.com/endorhq/rover/issues/143