### PR TITLE
fix: make AI agent debug output conditional on verbose flag

### DIFF
--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -2,7 +2,7 @@ import colors from 'ansi-colors';
 import { writeFileSync, chmodSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { TaskDescription } from './description.js';
-import { findProjectRoot, launchSync } from 'rover-common';
+import { findProjectRoot, launchSync, VERBOSE } from 'rover-common';
 
 /**
  * SetupBuilder class - Consolidates Docker setup script generation
@@ -356,15 +356,15 @@ setup_agent_environment() {
   private getAgentCommand(): string {
     switch (this.agent) {
       case 'claude':
-        return 'claude --dangerously-skip-permissions -p --debug';
+        return `claude --dangerously-skip-permissions -p${VERBOSE ? ' --debug' : ''}`;
       case 'codex':
-        return 'RUST_LOG=info codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check';
+        return `${VERBOSE ? 'RUST_LOG=info ' : ''}codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check`;
       case 'gemini':
-        return 'gemini --yolo -p --debug';
+        return `gemini --yolo -p${VERBOSE ? ' --debug' : ''}`;
       case 'qwen':
-        return 'qwen --yolo -p --debug';
+        return `qwen --yolo -p${VERBOSE ? ' --debug' : ''}`;
       default:
-        return 'claude --dangerously-skip-permissions -p --debug';
+        return `claude --dangerously-skip-permissions -p${VERBOSE ? ' --debug' : ''}`;
     }
   }
 


### PR DESCRIPTION
Fix AI agent debug output to only show when the user explicitly requests verbose mode, reducing unnecessary output during normal operations.

## Changes

- Import `VERBOSE` global variable from `rover-common` package
- Update `getAgentCommand()` method to conditionally add debug flags based on `VERBOSE` value
- Apply conditional debug flags for all AI agents (Claude, Gemini, Qwen, Codex)

## Notes

This change improves the user experience by reducing noise in the console output. Debug information is still available when needed by using the `--verbose` or `-v` flag with any Rover command.

Closes #175