### PR TITLE
feat(codex): update model used by default to be gpt-5-codex

### DIFF
--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -358,7 +358,7 @@ setup_agent_environment() {
       case 'claude':
         return `claude --dangerously-skip-permissions -p${VERBOSE ? ' --debug' : ''}`;
       case 'codex':
-        return `${VERBOSE ? 'RUST_LOG=info ' : ''}codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check`;
+        return `${VERBOSE ? 'RUST_LOG=info ' : ''}codex exec --model gpt-5-codex --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check`;
       case 'gemini':
         return `gemini --yolo -p${VERBOSE ? ' --debug' : ''}`;
       case 'qwen':


### PR DESCRIPTION
Updates the Codex agent configuration to use the gpt-5-codex model by default, improving AI capabilities for code generation and analysis tasks.

## Changes

- Modified the Codex agent command in `setup.ts` to include `--model gpt-5-codex` flag
- Updated the agent setup to use the newer GPT-5 Codex model instead of the default model