### PR TITLE
feat: add the publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,18 +90,26 @@ jobs:
           echo "ASSET_NAME=$ASSET_NAME" >> $GITHUB_ENV
 
       - name: Publish NPM (CLI)
-        if: inputs.project == 'cli'
+        if: inputs.project == 'cli' && inputs.dryRun == false
         run: |
           npm publish ${{ env.ASSET_NAME }} --access public 
           echo "✓ Successfully published to NPM"
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: (Dry Run) Publish NPM (CLI)
+        if: inputs.project == 'cli' && inputs.dryRun == false
+        run: echo "Skipping publish phase."
+
       - name: Publish VSCode Marketplace (Extension)
         if: inputs.project == 'extension'
         run: |
           npx @vscode/vsce publish --pat ${{ secrets.VSCODE_MARKETPLACE_TOKEN }} --packagePath ${{ github.workspace }}/${{ env.ASSET_NAME }}
           echo "✓ Successfully published to VSCode Marketplace"
+
+      - name: (Dry Run) Publish VSCode Marketplace (Extension)
+        if: inputs.project == 'extension' && inputs.dryRun == false
+        run: echo "Skipping publish phase"
 
       - name: Notify Google Chat on Success
         if: success() && inputs.dryRun == false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,3 +148,16 @@ jobs:
             "text": "❌ *Release Failed*\n\n*Project:* ${PROJECT}\n*Version:* v${VERSION}\n*Repository:* ${{ github.repository }}\n*Failed by:* ${{ github.actor }}\n*Workflow Run:* ${WORKFLOW_URL}\n\nPlease check the workflow logs for details."
           }
           EOF
+
+      - name: Trigger Publish Workflow
+        if: success() && inputs.publishRelease == true && inputs.dryRun == false
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Triggering publish workflow for ${{ inputs.project }} v${{ inputs.targetVersion }}"
+          gh workflow run publish.yml \
+            --repo ${{ github.repository }} \
+            --ref ${{ github.ref }} \
+            -f project=${{ inputs.project }} \
+            -f version=${{ inputs.targetVersion }} \
+            -f dryRun=${{ inputs.dryRun }}


### PR DESCRIPTION
Create a new publish job to release the CLI and the extension to the target registry. Instead of building the artifacts, it picks an existing release (from the release job), download the artifact and publish it.

Refs #180 

## Process
1. Clone
2. Check if the release exists
3. Download artifacts
4. Publish them
5. Notify Google Chat

## Other changes

- I updated some messages from the release job