### PR TITLE
fix: set missing extension properties and environment for the actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish
 run-name: (${{ github.event.inputs.project }}) Publish ${{ github.event.inputs.tag_name }}
 
+concurrency: production
+
 on:
   workflow_dispatch:
     inputs:
@@ -27,6 +29,7 @@ env:
 jobs:
   publish:
     timeout-minutes: 15
+    environment: production
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 run-name: (${{ github.event.inputs.project }}) Release ${{ github.event.inputs.targetVersion }} from ${{ github.ref_name }}
 
+concurrency: production
+
 on:
   workflow_dispatch:
     inputs:
@@ -30,6 +32,7 @@ on:
 jobs:
   release:
     timeout-minutes: 15
+    environment: production
     runs-on: ubuntu-latest
 
     steps:
@@ -64,6 +67,8 @@ jobs:
         run: npm run check:${{ inputs.project }}
 
       - name: Test
+        # For now, skip tests on the VSCode Extension
+        if: inputs.project == 'cli'
         run: npm run test:${{ inputs.project }}
 
       - name: Build

--- a/package-lock.json
+++ b/package-lock.json
@@ -8465,6 +8465,7 @@
     "packages/extension": {
       "name": "endor-rover",
       "version": "0.3.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.39",
         "execa": "^9.6.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,9 +1,9 @@
 {
   "name": "endor-rover",
-  "displayName": "Endor Rover",
+  "displayName": "Rover",
   "description": "Collaborate with AI agents to complete any task",
   "version": "0.3.0",
-  "publisher": "endor",
+  "publisher": "endorhq",
   "engines": {
     "vscode": "^1.102.0"
   },
@@ -13,6 +13,12 @@
   ],
   "icon": "./assets/logo.png",
   "main": "./dist/extension.js",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/endorhq/rover.git",
+    "directory": "packages/extension"
+  },
   "contributes": {
     "configuration": {
       "title": "Rover",


### PR DESCRIPTION
Fixes several issues:

- Run `test` script only for the CLI
- Add missing environment to the release and publish jobs
- Add missing properties to the extension manifest (`package.json`)

Refs #180