### PR TITLE
chore(extension): do not show error on a clean slate

### DIFF
--- a/packages/extension/src/rover/cli.mts
+++ b/packages/extension/src/rover/cli.mts
@@ -425,7 +425,7 @@ export class RoverCLI {
    */
   async checkInitialization(): Promise<boolean> {
     if (!this.workspaceRoot) {
-      throw new Error('unknown workspace root');
+      return false;
     }
 
     try {


### PR DESCRIPTION
Prevent the extension from throwing errors when the workspace is not initialized as a Rover project, improving the user experience for clean workspaces.

## Changes

- Modified `checkInitialization()` method in `RoverCLI` class to return `false` instead of throwing an error when workspace root is unknown
- Updated initialization guide component to handle uninitialized workspaces gracefully
- Improved task provider to not display error messages on clean slate workspaces

## Notes

This change addresses issue #187 by ensuring the extension doesn't show confusing error messages when users open VS Code in a workspace that hasn't been initialized with Rover yet. The extension now gracefully handles this state and guides users through the initialization process.

Fixes: https://github.com/endorhq/rover/issues/187