### PR TITLE
fix(extension): only show Initialize Rover button when workspace is open

### DIFF
--- a/packages/extension/src/providers/TasksLitWebviewProvider.mts
+++ b/packages/extension/src/providers/TasksLitWebviewProvider.mts
@@ -213,11 +213,15 @@ export class TasksLitWebviewProvider implements vscode.WebviewViewProvider {
     try {
       const cliStatus = await this.cli.checkInstallation();
       const roverInitialized = await this.cli.checkInitialization();
+      const workspaceOpen =
+        vscode.workspace.workspaceFolders &&
+        vscode.workspace.workspaceFolders.length > 0;
 
       const status = {
         cliInstalled: cliStatus.installed,
         cliVersion: cliStatus.version,
         roverInitialized,
+        workspaceOpen: !!workspaceOpen,
         error: cliStatus.error,
       };
 
@@ -240,6 +244,9 @@ export class TasksLitWebviewProvider implements vscode.WebviewViewProvider {
         status: {
           cliInstalled: false,
           roverInitialized: false,
+          workspaceOpen:
+            vscode.workspace.workspaceFolders &&
+            vscode.workspace.workspaceFolders.length > 0,
           error: error instanceof Error ? error.message : 'Unknown error',
         },
       });

--- a/packages/extension/src/views/components/initialization-guide.mts
+++ b/packages/extension/src/views/components/initialization-guide.mts
@@ -6,6 +6,7 @@ import logo from '../common/logo.svg';
 export interface InitializationStatus {
   cliInstalled: boolean;
   roverInitialized: boolean;
+  workspaceOpen: boolean;
   cliVersion?: string;
   error?: string;
 }
@@ -72,7 +73,8 @@ export class InitializationGuide extends LitElement {
       `;
     }
 
-    const { cliInstalled, roverInitialized, cliVersion, error } = this.status;
+    const { cliInstalled, roverInitialized, workspaceOpen, cliVersion, error } =
+      this.status;
 
     return html`
       <div class="guide-container">
@@ -168,20 +170,26 @@ export class InitializationGuide extends LitElement {
                     </div>
                   `
                 : cliInstalled
-                  ? html`
-                      <div class="step-actions">
-                        <button
-                          class="action-button"
-                          @click=${this.handleInitializeRover}
-                          ?disabled=${this.isInitializing}
-                        >
-                          ${this.isInitializing
-                            ? html`<div class="loading-spinner"></div>`
-                            : ''}
-                          Initialize Rover
-                        </button>
-                      </div>
-                    `
+                  ? workspaceOpen
+                    ? html`
+                        <div class="step-actions">
+                          <button
+                            class="action-button"
+                            @click=${this.handleInitializeRover}
+                            ?disabled=${this.isInitializing}
+                          >
+                            ${this.isInitializing
+                              ? html`<div class="loading-spinner"></div>`
+                              : ''}
+                            Initialize Rover
+                          </button>
+                        </div>
+                      `
+                    : html`
+                        <div class="step-description">
+                          Please open a workspace folder to initialize Rover.
+                        </div>
+                      `
                   : html`
                       <div class="step-description">
                         Install the CLI first to continue with initialization.


### PR DESCRIPTION
Improve the Rover extension's initialization guide to only display the "Initialize Rover" button when a workspace folder is actually open in VS Code. This prevents users from trying to initialize Rover in an empty workspace, which would fail.

## Changes

- Added `workspaceOpen` property to initialization status tracking
- Modified initialization guide component to check workspace state before showing the initialize button
- Updated webview provider to include workspace folder detection in status checks
- Display helpful message when no workspace is open instead of showing non-functional button

## Notes

This change improves the user experience by preventing failed initialization attempts and providing clear guidance about the workspace requirement.

Fixes: #188