### PR TITLE
fix: handle missing iteration status.json file in list command

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -8,6 +8,7 @@ import {
   getLastTaskIteration,
   getTaskIterations,
   IterationConfig,
+  IterationStatus,
 } from '../lib/iteration.js';
 
 /**
@@ -190,6 +191,16 @@ export const listCommand = async (
 
       const agent = task.agent || '-';
 
+      const maybeIterationStatus: (
+        iteration?: IterationConfig
+      ) => IterationStatus | undefined = iteration => {
+        try {
+          return iteration?.status();
+        } catch (e) {
+          return undefined;
+        }
+      };
+
       let row = '';
       row += colors.cyan(task.id.toString().padEnd(columnWidths[0]));
       row += colors.white(
@@ -199,15 +210,15 @@ export const listCommand = async (
       row += colorFunc(formatTaskStatus(taskStatus).padEnd(columnWidths[3])); // +10 for ANSI codes
       row += formatProgress(
         taskStatus,
-        lastIteration?.status()?.progress || 0
+        maybeIterationStatus(lastIteration)?.progress || 0
       ).padEnd(columnWidths[4] + 10);
       row += colors.gray(
         truncateText(
-          lastIteration?.status()?.currentStep || '-',
+          maybeIterationStatus(lastIteration)?.currentStep || '-',
           columnWidths[5] - 1
         ).padEnd(columnWidths[5])
       );
-      row += colors.gray(lastIteration?.status() ? duration : '-');
+      row += colors.gray(maybeIterationStatus(lastIteration) ? duration : '-');
       console.log(row);
 
       // Show error in verbose mode


### PR DESCRIPTION
Fix handling of missing iteration `status.json` files in the list command to prevent crashes when listing tasks that don't have a first iteration status file.

The list command was failing when trying to access the status of task iterations that didn't have a `status.json` file present, causing the entire listing operation to crash.

## Changes

- Added `maybeIterationStatus()` helper function to safely handle missing status files
- Wrapped `iteration.status()` calls in try-catch blocks to prevent crashes
- Return `undefined` when status file is not present instead of throwing an error
- Updated progress and current step display logic to handle undefined status gracefully

## Notes

This fix ensures that the list command is resilient to incomplete or corrupted task iterations, allowing users to see all their tasks even when some iterations lack status files.

Closes #192