### PR TITLE
fix: ensure iterate command respects --json flag for all output

### DIFF
--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -19,7 +19,6 @@ import { showRoverChat } from '../utils/display.js';
 import { readFromStdin, stdinIsAvailable } from '../utils/stdin.js';
 import { CLIJsonOutput } from '../types.js';
 import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
-import { fa } from 'zod/locales';
 
 const { prompt } = enquirer;
 
@@ -138,7 +137,7 @@ const expandIterationInstructions = async (
 export const iterateCommand = async (
   taskId: string,
   instructions?: string,
-  options: { follow?: boolean; json?: boolean } = {}
+  options: { json?: boolean } = {}
 ): Promise<void> => {
   const telemetry = getTelemetry();
   const json = options.json === true;
@@ -441,7 +440,6 @@ export const iterateCommand = async (
       task.worktreePath,
       iterationPath,
       selectedAiAgent,
-      options.follow,
       options.json
     );
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -260,7 +260,6 @@ program
     '[instructions]',
     'New requirements or refinement instructions to apply (will prompt if not provided)'
   )
-  .option('-f, --follow', 'Follow execution logs in real-time')
   .option('--json', 'Output JSON and skip confirmation prompts')
   .action(iterateCommand);
 


### PR DESCRIPTION
Fix the iterate command to properly handle the `--json` flag by ensuring all console output is suppressed when JSON mode is active. This resolves VSCode extension errors when running iterate commands.

## Changes

- Removed unused import of `fa` from zod/locales
- Removed the `--follow` option which was not being used
- Fixed `startDockerExecution` call to pass the json option correctly

## Notes

The issue was that the iterate command was outputting extra logs when the `--json` flag was passed, causing the VSCode extension to fail when parsing the JSON response. This fix ensures that the json option is properly passed through to all relevant functions.

Closes #176