### PR TITLE
fix: handle Ctrl-C as cancellation in delete command confirmation

### DIFF
--- a/packages/cli/src/commands/__tests__/delete.test.ts
+++ b/packages/cli/src/commands/__tests__/delete.test.ts
@@ -29,9 +29,9 @@ vi.mock('enquirer', () => ({
 
 // Mock exit utilities to prevent process.exit
 vi.mock('../../utils/exit.js', () => ({
-  exitWithErrors: vi.fn().mockImplementation(() => {}),
-  exitWithSuccess: vi.fn().mockImplementation(() => {}),
-  exitWithWarn: vi.fn().mockImplementation(() => {}),
+  exitWithErrors: vi.fn().mockImplementation(() => { }),
+  exitWithSuccess: vi.fn().mockImplementation(() => { }),
+  exitWithWarn: vi.fn().mockImplementation(() => { }),
 }));
 
 // Mock display utilities to suppress output
@@ -262,6 +262,29 @@ describe('delete command', () => {
 
       // Task should still exist
       expect(existsSync('.rover/tasks/5')).toBe(true);
+    });
+
+    it('should treat Ctrl-C as cancellation', async () => {
+      createTestTask(26, 'Ctrl-C Task');
+
+      // Mock enquirer to throw an error simulating Ctrl-C
+      const enquirer = await import('enquirer');
+      vi.mocked(enquirer.default.prompt).mockRejectedValue(new Error('User cancelled'));
+
+      const { exitWithErrors } = await import('../../utils/exit.js');
+
+      await deleteCommand(['26']);
+
+      expect(exitWithErrors).toHaveBeenCalledWith(
+        {
+          success: false,
+          errors: ['Task deletion cancelled'],
+        },
+        false
+      );
+
+      // Task should still exist (not deleted)
+      expect(existsSync('.rover/tasks/26')).toBe(true);
     });
 
     it('should proceed when user confirms deletion', async () => {

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -19,7 +19,7 @@ const { prompt } = enquirer;
 /**
  * Interface for JSON output
  */
-interface TaskDeleteOutput extends CLIJsonOutputWithErrors {}
+interface TaskDeleteOutput extends CLIJsonOutputWithErrors { }
 
 export const deleteCommand = async (
   taskIds: string[],
@@ -106,19 +106,19 @@ export const deleteCommand = async (
 
       console.log(
         colors.gray(`${prefix} ID: `) +
-          colors.cyan(task.id.toString()) +
-          colors.gray(' | Title: ') +
-          colors.white(task.title) +
-          colors.gray(' | Status: ') +
-          colorFunc(task.status)
+        colors.cyan(task.id.toString()) +
+        colors.gray(' | Title: ') +
+        colors.white(task.title) +
+        colors.gray(' | Status: ') +
+        colorFunc(task.status)
       );
     });
 
     console.log(
       '\n' +
-        colors.white(
-          `This action will delete the task${tasksToDelete.length > 1 ? 's' : ''} metadata and workspace${tasksToDelete.length > 1 ? 's' : ''} (git worktree${tasksToDelete.length > 1 ? 's' : ''})`
-        )
+      colors.white(
+        `This action will delete the task${tasksToDelete.length > 1 ? 's' : ''} metadata and workspace${tasksToDelete.length > 1 ? 's' : ''} (git worktree${tasksToDelete.length > 1 ? 's' : ''})`
+      )
     );
   }
 
@@ -135,7 +135,7 @@ export const deleteCommand = async (
       confirmDeletion = confirm;
     } catch (_err) {
       // User cancelled, exit without doing anything
-      jsonOutput.errors?.push('Task deletion cancelled');
+      confirmDeletion = false;
     }
   }
 


### PR DESCRIPTION
Fix the delete command to properly handle Ctrl-C (interrupt signal) as a cancellation rather than treating it as confirmation. This ensures that tasks are not accidentally deleted when users cancel the operation.

## Changes

- Modified error handling in the delete command to treat any error during confirmation prompt as cancellation
- Added test case to verify Ctrl-C properly cancels the deletion
- Simplified the cancellation flow by setting `confirmDeletion = false` instead of adding to errors array

## Notes

Previously, when users pressed Ctrl-C during the deletion confirmation prompt, the command would proceed with the deletion. This fix ensures that any interruption or error during the prompt is treated as a rejection, preventing accidental task deletion.

Closes #173