### PR TITLE
fix: improve error handling in merge command commit process

### DIFF
--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -447,13 +447,13 @@ export const mergeCommand = async (
         if (spinner) spinner.text = 'Committing changes in worktree...';
 
         // Switch to worktree and commit changes
-        const commitResult = git.addAndCommit(finalCommitMessage, {
-          worktreePath: task.worktreePath,
-        });
-
-        jsonOutput.committed = commitResult;
-
-        if (!commitResult) {
+        try {
+          git.addAndCommit(finalCommitMessage, {
+            worktreePath: task.worktreePath,
+          });
+          jsonOutput.committed = true;
+        } catch (error) {
+          jsonOutput.committed = false;
           spinner?.error('Failed to commit changes');
           jsonOutput.error =
             'Failed to add and commit changes in the workspace';

--- a/packages/common/src/git.ts
+++ b/packages/common/src/git.ts
@@ -183,20 +183,14 @@ export class Git {
   /**
    * Add all files and commit it
    */
-  addAndCommit(message: string, options: GitWorktreeOptions = {}): boolean {
-    try {
-      launchSync('git', ['add', '-A'], {
-        cwd: options.worktreePath,
-      });
+  addAndCommit(message: string, options: GitWorktreeOptions = {}): void {
+    launchSync('git', ['add', '-A'], {
+      cwd: options.worktreePath,
+    });
 
-      launchSync('git', ['commit', '-m', message], {
-        cwd: options.worktreePath,
-      });
-
-      return true;
-    } catch (_err) {
-      return false;
-    }
+    launchSync('git', ['commit', '-m', message], {
+      cwd: options.worktreePath,
+    });
   }
 
   /**


### PR DESCRIPTION
Improves error handling in the merge command by simplifying the commit process and ensuring proper exception propagation. The previous implementation could silently fail during commits, leading to incomplete merges.

Closes #178

## Changes

- Simplified `addAndCommit()` method in Git class to throw exceptions directly instead of returning boolean success/failure
- Updated merge command to use try-catch for commit operations with proper error handling
- Removed boolean return logic that could mask underlying git commit failures
- Improved error reporting when workspace commits fail during merge process

## Notes

This change makes the commit process more reliable by ensuring that any git failures are properly propagated as exceptions rather than being silently converted to boolean values. The merge command now provides clearer feedback when commit operations fail.