### PR TITLE
chore: download package-manager-mcp from GH releases

### DIFF
--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -101,7 +101,8 @@ configure-mcp-servers() {
 # Task description is mounted at /task/description.json
 
 # Download and install the MCP server
-wget -O /usr/local/bin/package-manager-mcp-server https://images.endor.dev/rover/assets/package-manager-mcp-$(uname -m)-unknown-linux-musl
+export PACKAGE_MANAGER_MCP_SERVER_VERSION=v0.1.3
+wget -O /usr/local/bin/package-manager-mcp-server https://github.com/endorhq/package-manager-mcp/releases/download/\${PACKAGE_MANAGER_MCP_SERVER_VERSION}/package-manager-mcp-$(uname -m)-unknown-linux-musl
 chmod +x /usr/local/bin/package-manager-mcp-server
 
 echo "======================================="


### PR DESCRIPTION
Update the package-manager-mcp server installation to download from GitHub releases instead of using a custom images URL. This change improves maintainability and follows standard distribution practices.

## Changes

- Updated the wget URL in `packages/cli/src/lib/setup.ts` to fetch from GitHub releases
- Added version variable `PACKAGE_MANAGER_MCP_SERVER_VERSION=v0.1.3` for better version management
- Changed from `https://images.endor.dev/rover/assets/package-manager-mcp-$(uname -m)-unknown-linux-musl` to `https://github.com/endorhq/package-manager-mcp/releases/download/${PACKAGE_MANAGER_MCP_SERVER_VERSION}/package-manager-mcp-$(uname -m)-unknown-linux-musl`

## Notes

This change makes version updates easier by using a dedicated version variable and aligns with standard GitHub release distribution patterns.

Closes: #208