### PR TITLE
feat: pass AI agent environment variables to Docker containers

### DIFF
--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -202,6 +202,7 @@ export const startDockerExecution = async (
   // Get agent-specific Docker mounts
   const agent = getAIAgentTool(selectedAiAgent);
   const dockerMounts: string[] = agent.getContainerMounts();
+  const envVariables: string[] = agent.getEnvironmentVariables();
 
   if (!jsonMode) {
     console.log(colors.white.bold('\n🐳 Starting Docker container:'));
@@ -252,6 +253,7 @@ export const startDockerExecution = async (
       `${iterationJsonPath}:/task/description.json:Z,ro`,
       '-v',
       `${promptsDir}:/prompts:Z,ro`,
+      ...envVariables,
       '-w',
       '/workspace',
       'node:24-alpine',

--- a/packages/cli/src/lib/agents/claude.ts
+++ b/packages/cli/src/lib/agents/claude.ts
@@ -19,6 +19,48 @@ const findKeychainCredentials = (key: string): string => {
   return result.stdout?.toString() || '';
 };
 
+// Environment variables reference:
+// - https://docs.claude.com/en/docs/claude-code/settings.md
+// - https://docs.claude.com/es/docs/claude-code/google-vertex-ai.md
+// - https://docs.claude.com/es/docs/claude-code/amazon-bedrock.md
+// - https://docs.claude.com/es/docs/claude-code/llm-gateway.md
+const CLAUDE_CODE_ENV_VARS = [
+  // AWS/Bedrock configuration
+  'AWS_REGION',
+  'AWS_ACCESS_KEY_ID',
+  'AWS_SECRET_ACCESS_KEY',
+  'AWS_SESSION_TOKEN',
+  'AWS_PROFILE',
+  'AWS_BEARER_TOKEN_BEDROCK',
+
+  // Google Vertex AI configuration
+  'CLOUD_ML_REGION',
+  'ANTHROPIC_VERTEX_PROJECT_ID',
+  'VERTEX_REGION_CLAUDE_3_5_HAIKU',
+  'VERTEX_REGION_CLAUDE_3_5_SONNET',
+  'VERTEX_REGION_CLAUDE_3_7_SONNET',
+  'VERTEX_REGION_CLAUDE_4_0_OPUS',
+  'VERTEX_REGION_CLAUDE_4_0_SONNET',
+  'VERTEX_REGION_CLAUDE_4_1_OPUS',
+
+  // General configuration
+  'BASH_DEFAULT_TIMEOUT_MS',
+  'BASH_MAX_OUTPUT_LENGTH',
+  'BASH_MAX_TIMEOUT_MS',
+  'CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR',
+  'DISABLE_AUTOUPDATER',
+  'DISABLE_BUG_COMMAND',
+  'DISABLE_COST_WARNINGS',
+  'DISABLE_ERROR_REPORTING',
+  'DISABLE_NON_ESSENTIAL_MODEL_CALLS',
+  'DISABLE_PROMPT_CACHING',
+  'DISABLE_TELEMETRY',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'MAX_MCP_OUTPUT_TOKENS',
+  'MAX_THINKING_TOKENS',
+];
+
 class ClaudeAI implements AIAgentTool {
   // constants
   public AGENT_BIN = 'claude';
@@ -184,6 +226,26 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     }
 
     return dockerMounts;
+  }
+
+  getEnvironmentVariables(): string[] {
+    const envVars: string[] = [];
+
+    // Look for any ANTHROPIC_* and CLAUDE_CODE_* env vars
+    for (const key in process.env) {
+      if (key.startsWith('ANTHROPIC_') || key.startsWith('CLAUDE_CODE_')) {
+        envVars.push('-e', key);
+      }
+    }
+
+    // Add other specific environment variables from CLAUDE_CODE_ENV_VARS
+    for (const key of CLAUDE_CODE_ENV_VARS) {
+      if (process.env[key] !== undefined) {
+        envVars.push('-e', key);
+      }
+    }
+
+    return envVars;
   }
 }
 

--- a/packages/cli/src/lib/agents/codex.ts
+++ b/packages/cli/src/lib/agents/codex.ts
@@ -11,6 +11,25 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { fileSync } from 'tmp';
 
+// Environment variables reference:
+// - https://raw.githubusercontent.com/openai/codex/refs/heads/main/docs/config.md
+const CODEX_ENV_VARS = [
+  // Azure OpenAI configuration
+  'AZURE_OPENAI_API_KEY',
+
+  // OpenTelemetry configuration
+  'OTLP_TOKEN',
+
+  // System environment variables
+  'TMPDIR',
+  'PATH',
+  'HOME',
+  'USER',
+
+  // CI/CD configuration
+  'CI',
+];
+
 class CodexAI implements AIAgentTool {
   // constants
   public AGENT_BIN = 'codex';
@@ -144,6 +163,26 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     }
 
     return dockerMounts;
+  }
+
+  getEnvironmentVariables(): string[] {
+    const envVars: string[] = [];
+
+    // Look for any CODEX_* and OPENAI_* env vars
+    for (const key in process.env) {
+      if (key.startsWith('CODEX_') || key.startsWith('OPENAI_')) {
+        envVars.push('-e', key);
+      }
+    }
+
+    // Add other specific environment variables from CODEX_ENV_VARS
+    for (const key of CODEX_ENV_VARS) {
+      if (process.env[key] !== undefined) {
+        envVars.push('-e', key);
+      }
+    }
+
+    return envVars;
   }
 }
 

--- a/packages/cli/src/lib/agents/gemini.ts
+++ b/packages/cli/src/lib/agents/gemini.ts
@@ -10,6 +10,23 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 
+// Environment variables reference:
+// - https://raw.githubusercontent.com/google-gemini/gemini-cli/refs/heads/main/docs/cli/configuration.md
+const GEMINI_ENV_VARS = [
+  // OpenTelemetry configuration
+  'OTLP_GOOGLE_CLOUD_PROJECT',
+
+  // Sandbox and debugging
+  'SEATBELT_PROFILE',
+  'DEBUG',
+  'DEBUG_MODE',
+
+  // General configuration
+  'NO_COLOR',
+  'CLI_TITLE',
+  'CODE_ASSIST_ENDPOINT',
+];
+
 class GeminiAI implements AIAgentTool {
   // constants
   public AGENT_BIN = 'gemini';
@@ -141,6 +158,26 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     }
 
     return dockerMounts;
+  }
+
+  getEnvironmentVariables(): string[] {
+    const envVars: string[] = [];
+
+    // Look for any GEMINI_* and GOOGLE_* env vars
+    for (const key in process.env) {
+      if (key.startsWith('GEMINI_') || key.startsWith('GOOGLE_')) {
+        envVars.push('-e', key);
+      }
+    }
+
+    // Add other specific environment variables from GEMINI_ENV_VARS
+    for (const key of GEMINI_ENV_VARS) {
+      if (process.env[key] !== undefined) {
+        envVars.push('-e', key);
+      }
+    }
+
+    return envVars;
   }
 }
 

--- a/packages/cli/src/lib/agents/index.ts
+++ b/packages/cli/src/lib/agents/index.ts
@@ -39,6 +39,9 @@ export interface AIAgentTool {
 
   // Get Docker mount strings for agent-specific credential files
   getContainerMounts(): string[];
+
+  // Get Container environment variables for this tool
+  getEnvironmentVariables(): string[];
 }
 
 export class MissingAIAgentError extends Error {

--- a/packages/cli/src/lib/agents/qwen.ts
+++ b/packages/cli/src/lib/agents/qwen.ts
@@ -10,6 +10,25 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 
+// Environment variables reference:
+// - https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/cli/configuration.md
+const QWEN_ENV_VARS = [
+  // Sandbox and debugging
+  'GEMINI_SANDBOX',
+  'SEATBELT_PROFILE',
+  'DEBUG',
+  'DEBUG_MODE',
+  'BUILD_SANDBOX',
+
+  // General configuration
+  'NO_COLOR',
+  'CLI_TITLE',
+  'CODE_ASSIST_ENDPOINT',
+
+  // Web search configuration
+  'TAVILY_API_KEY',
+];
+
 class QwenAI implements AIAgentTool {
   // constants
   public AGENT_BIN = 'qwen';
@@ -141,6 +160,26 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     }
 
     return dockerMounts;
+  }
+
+  getEnvironmentVariables(): string[] {
+    const envVars: string[] = [];
+
+    // Look for any QWEN_* and OPENAI_* env vars
+    for (const key in process.env) {
+      if (key.startsWith('QWEN_') || key.startsWith('OPENAI_')) {
+        envVars.push('-e', key);
+      }
+    }
+
+    // Add other specific environment variables from QWEN_ENV_VARS
+    for (const key of QWEN_ENV_VARS) {
+      if (process.env[key] !== undefined) {
+        envVars.push('-e', key);
+      }
+    }
+
+    return envVars;
   }
 }
 


### PR DESCRIPTION
Enables AI agent CLI tools running in Docker containers to access host environment variables for authentication and configuration.

## Changes

- Added `getEnvironmentVariables()` method to `AIAgentTool` interface
- Implemented environment variable collection for Claude, Gemini, Codex, and Qwen agents
- Updated `startDockerExecution()` to forward collected variables to containers
- Added documentation references for each agent's supported variables

Each agent automatically forwards prefix-matched variables (e.g., `ANTHROPIC_*`, `GEMINI_*`) plus additional cross-agent variables like proxy settings, cloud credentials, and debugging flags.

Closes #207