### PR TITLE
fix: remove hardcoded white text for better terminal compatibility

### DIFF
--- a/packages/agent/src/commands/install.ts
+++ b/packages/agent/src/commands/install.ts
@@ -30,14 +30,14 @@ export const installCommand = async (
   };
 
   try {
-    console.log(colors.white.bold('Agent Installation'));
+    console.log(colors.bold('Agent Installation'));
     console.log(colors.gray('├── Agent: ') + colors.cyan(agentName));
     console.log(colors.gray('└── Version: ') + colors.cyan(options.version));
 
     // Create agent instance
     const agent = createAgent(agentName, options.version);
 
-    console.log(colors.white.bold('\nValidating Credentials'));
+    console.log(colors.bold('\nValidating Credentials'));
 
     // Validate agent credentials
     const validation = agent.validateCredentials();

--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -84,21 +84,17 @@ export const runCommand = async (
       }
     }
 
-    console.log(colors.white.bold('Agent Workflow'));
+    console.log(colors.bold('Agent Workflow'));
     console.log(colors.gray('├── Name: ') + colors.cyan(agentWorkflow.name));
-    console.log(
-      colors.gray('└── Description: ') + colors.white(agentWorkflow.description)
-    );
+    console.log(colors.gray('└── Description: ') + agentWorkflow.description);
 
-    console.log(colors.white.bold('\nUser inputs'));
+    console.log(colors.bold('\nUser inputs'));
     const inputEntries = Array.from(inputs.entries());
     inputEntries.forEach(([key, value], idx) => {
       const prefix = idx == inputEntries.length - 1 ? '└──' : '├──';
       const isDefault = defaultInputs.includes(key);
       const suffix = isDefault ? colors.gray(' (default)') : '';
-      console.log(
-        colors.white(`${prefix} ${key}=`) + colors.cyan(`${value}`) + suffix
-      );
+      console.log(`${prefix} ${key}=` + colors.cyan(`${value}`) + suffix);
     });
 
     // Validate inputs against workflow requirements
@@ -125,12 +121,10 @@ export const runCommand = async (
       const stepsOutput: Map<string, Map<string, string>> = new Map();
 
       // Print Steps
-      console.log(colors.white.bold('\nSteps'));
+      console.log(colors.bold('\nSteps'));
       agentWorkflow.steps.forEach((step, idx) => {
         const prefix = idx == agentWorkflow.steps.length - 1 ? '└──' : '├──';
-        console.log(
-          colors.white(`${prefix} ${idx}. `) + colors.white(`${step.name}`)
-        );
+        console.log(`${prefix} ${idx}. ` + `${step.name}`);
       });
 
       let runSteps = 0;
@@ -160,7 +154,7 @@ export const runCommand = async (
         const result = await runner.run();
 
         // Display step results
-        console.log(colors.white.bold(`\n📊 Step Results: ${step.name}`));
+        console.log(colors.bold(`\n📊 Step Results: ${step.name}`));
         console.log(colors.gray('├── ID: ') + colors.cyan(result.id));
         console.log(
           colors.gray('├── Status: ') +
@@ -241,7 +235,7 @@ export const runCommand = async (
       }
 
       // Display workflow completion summary
-      console.log(colors.white.bold('\n🎉 Workflow Execution Summary'));
+      console.log(colors.bold('\n🎉 Workflow Execution Summary'));
       console.log(
         colors.gray('├── Total Steps: ') +
           colors.cyan(agentWorkflow.steps.length.toString())

--- a/packages/agent/src/lib/agents/base.ts
+++ b/packages/agent/src/lib/agents/base.ts
@@ -45,7 +45,7 @@ export abstract class BaseAgent implements Agent {
   async install(): Promise<void> {
     const command = this.getInstallCommand();
 
-    console.log(colors.white.bold(`\nInstalling ${this.name} CLI`));
+    console.log(colors.bold(`\nInstalling ${this.name} CLI`));
     console.log(colors.gray('├── Version: ') + colors.cyan(this.version));
     console.log(colors.gray('└── Command: ') + colors.cyan(command));
 

--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -28,7 +28,7 @@ export class ClaudeAgent extends BaseAgent {
   }
 
   async copyCredentials(targetDir: string): Promise<void> {
-    console.log(colors.white.bold(`\nCopying ${this.name} credentials`));
+    console.log(colors.bold(`\nCopying ${this.name} credentials`));
 
     const targetClaudeDir = join(targetDir, '.claude');
     // Ensure .claude directory exists

--- a/packages/agent/src/lib/agents/codex.ts
+++ b/packages/agent/src/lib/agents/codex.ts
@@ -28,7 +28,7 @@ export class CodexAgent extends BaseAgent {
   }
 
   async copyCredentials(targetDir: string): Promise<void> {
-    console.log(colors.white.bold(`\nCopying ${this.name} credentials`));
+    console.log(colors.bold(`\nCopying ${this.name} credentials`));
 
     const targetCodexDir = join(targetDir, '.codex');
     // Ensure .codex directory exists

--- a/packages/agent/src/lib/agents/gemini.ts
+++ b/packages/agent/src/lib/agents/gemini.ts
@@ -33,7 +33,7 @@ export class GeminiAgent extends BaseAgent {
   }
 
   async copyCredentials(targetDir: string): Promise<void> {
-    console.log(colors.white.bold(`\nCopying ${this.name} credentials`));
+    console.log(colors.bold(`\nCopying ${this.name} credentials`));
 
     const targetGeminiDir = join(targetDir, '.gemini');
     // Ensure .gemini directory exists

--- a/packages/agent/src/lib/agents/qwen.ts
+++ b/packages/agent/src/lib/agents/qwen.ts
@@ -33,7 +33,7 @@ export class QwenAgent extends BaseAgent {
   }
 
   async copyCredentials(targetDir: string): Promise<void> {
-    console.log(colors.white.bold(`\nCopying ${this.name} credentials`));
+    console.log(colors.bold(`\nCopying ${this.name} credentials`));
 
     const targetQwenDir = join(targetDir, '.qwen');
     // Ensure .qwen directory exists

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -96,7 +96,7 @@ export const deleteCommand = async (
     showRoverChat(["It's time to cleanup some tasks!"]);
 
     console.log(
-      colors.white.bold(`Task${tasksToDelete.length > 1 ? 's' : ''} to delete`)
+      colors.bold(`Task${tasksToDelete.length > 1 ? 's' : ''} to delete`)
     );
 
     tasksToDelete.forEach((task, index) => {
@@ -108,7 +108,7 @@ export const deleteCommand = async (
         colors.gray(`${prefix} ID: `) +
           colors.cyan(task.id.toString()) +
           colors.gray(' | Title: ') +
-          colors.white(task.title) +
+          task.title +
           colors.gray(' | Status: ') +
           colorFunc(task.status)
       );
@@ -116,9 +116,7 @@ export const deleteCommand = async (
 
     console.log(
       '\n' +
-        colors.white(
-          `This action will delete the task${tasksToDelete.length > 1 ? 's' : ''} metadata and workspace${tasksToDelete.length > 1 ? 's' : ''} (git worktree${tasksToDelete.length > 1 ? 's' : ''})`
-        )
+        `This action will delete the task${tasksToDelete.length > 1 ? 's' : ''} metadata and workspace${tasksToDelete.length > 1 ? 's' : ''} (git worktree${tasksToDelete.length > 1 ? 's' : ''})`
     );
   }
 

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -44,22 +44,16 @@ export const diffCommand = async (
     }
 
     console.log(colors.bold(`Task ${numericTaskId} Changes`));
-    console.log(colors.gray('├── Title: ') + colors.white(task.title));
-    console.log(
-      colors.gray('├── Workspace: ') + colors.white(task.worktreePath)
-    );
+    console.log(colors.gray('├── Title: ') + task.title);
+    console.log(colors.gray('├── Workspace: ') + task.worktreePath);
 
     if (options.branch) {
-      console.log(
-        colors.gray('├── Task Branch: ') + colors.white(task.branchName)
-      );
+      console.log(colors.gray('├── Task Branch: ') + task.branchName);
       console.log(
         colors.gray('└── Comparing with: ') + colors.cyan(options.branch)
       );
     } else {
-      console.log(
-        colors.gray('└── Task Branch: ') + colors.white(task.branchName)
-      );
+      console.log(colors.gray('└── Task Branch: ') + task.branchName);
     }
 
     telemetry?.eventDiff();
@@ -87,7 +81,7 @@ export const diffCommand = async (
           }
         } else {
           if (options.onlyFiles) {
-            console.log(colors.bold.white('\nChanged Files'));
+            console.log(colors.bold('\nChanged Files'));
             // Display file list with colors
             const files = diffOutput?.trim().split('\n') || [];
 
@@ -107,7 +101,7 @@ export const diffCommand = async (
               } else if (line.startsWith('-') && !line.startsWith('---')) {
                 console.log(colors.red(line));
               } else if (line.startsWith('diff --git')) {
-                console.log(colors.bold(colors.white(line)));
+                console.log(colors.bold(line));
               } else if (
                 line.startsWith('index ') ||
                 line.startsWith('+++') ||

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -122,7 +122,7 @@ export const initCommand = async (
     reqSpinner.fail('Your system misses some required tools');
   }
 
-  console.log(colors.white.bold('\nRequired Tools'));
+  console.log(colors.bold('\nRequired Tools'));
   console.log(
     `├── Git: ${gitInstalled ? colors.green('✓ Installed') : colors.red('✗ Missing')}`
   );
@@ -130,7 +130,7 @@ export const initCommand = async (
     `└── Docker: ${dockerInstalled ? colors.green('✓ Installed') : colors.red('✗ Missing')}`
   );
 
-  console.log(colors.white.bold('\nAI Agents (at least one)'));
+  console.log(colors.bold('\nAI Agents (at least one)'));
   console.log(
     `├── Claude: ${claudeInstalled ? colors.green('✓ Installed') : colors.red('✗ Missing')}`
   );
@@ -166,7 +166,7 @@ export const initCommand = async (
   try {
     await ensureGitignore(path);
   } catch (error) {
-    console.log(colors.white.bold('\n.gitignore'));
+    console.log(colors.bold('\n.gitignore'));
     console.log(
       `└── ${colors.yellow('⚠ Could not update .gitignore:')}`,
       error
@@ -229,7 +229,7 @@ export const initCommand = async (
     let attribution = true;
 
     if (!options.yes) {
-      console.log(colors.white.bold('\nAttribution'));
+      console.log(colors.bold('\nAttribution'));
       // Confirm attribution
       console.log(
         colors.gray(

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -213,34 +213,28 @@ export const inspectCommand = async (
       // Status color
       const statusColorFunc = statusColor(task.status);
 
-      console.log(colors.bold.white('\nTask Details'));
+      console.log(colors.bold('\nTask Details'));
       console.log(
         `├── ${colors.gray('ID: ')} ${colors.cyan(task.id.toString())} (${colors.gray(task.uuid)})`
       );
-      console.log('├── ' + colors.gray('Title: ') + colors.white(task.title));
+      console.log('├── ' + colors.gray('Title: ') + task.title);
       console.log(
         '├── ' + colors.gray('Status: ') + statusColorFunc(formattedStatus)
       );
       console.log(
-        '├── ' +
-          colors.gray('Directory: ') +
-          colors.white(`.rover/tasks/${numericTaskId}/`)
+        '├── ' + colors.gray('Directory: ') + `.rover/tasks/${numericTaskId}/`
       );
-      console.log(
-        '├── ' + colors.gray('Workspace: ') + colors.white(task.worktreePath)
-      );
-      console.log(
-        '└── ' + colors.gray('Branch: ') + colors.white(task.branchName)
-      );
+      console.log('├── ' + colors.gray('Workspace: ') + task.worktreePath);
+      console.log('└── ' + colors.gray('Branch: ') + task.branchName);
 
-      console.log(colors.bold.white('\nDescription:'));
+      console.log(colors.bold('\nDescription:'));
       console.log(colors.gray(task.description));
 
-      console.log(colors.bold.white('\nTimestamps'));
+      console.log(colors.bold('\nTimestamps'));
       console.log(
         '├── ' +
           colors.gray('Created: ') +
-          colors.white(new Date(task.createdAt).toLocaleString())
+          new Date(task.createdAt).toLocaleString()
       );
 
       // Show completion time if completed
@@ -267,7 +261,7 @@ export const inspectCommand = async (
       // Show error if failed
       if (task.error) {
         console.log(colors.red('\nError: '));
-        console.log(colors.white(task.error));
+        console.log(task.error);
       }
 
       const discoveredFiles = discoverIterationFiles(
@@ -277,13 +271,13 @@ export const inspectCommand = async (
 
       if (discoveredFiles.length > 0) {
         console.log(
-          colors.bold.white('\nIteration Details ') +
+          colors.bold('\nIteration Details ') +
             colors.gray(`${iterationNumber}/${task.iterations}`)
         );
 
-        console.log('└── ' + colors.white('Files:'));
+        console.log('└── ' + 'Files:');
         for (const file of discoveredFiles) {
-          console.log(colors.white(`     └── ${colors.cyan(file)}`));
+          console.log(`     └── ${colors.cyan(file)}`);
         }
 
         const fileFilter = options.file || ['summary.md'];
@@ -300,7 +294,7 @@ export const inspectCommand = async (
             )
           );
         } else {
-          console.log(colors.white.bold('\nOutput content:'));
+          console.log(colors.bold('\nOutput content:'));
           iterationFileContents.forEach((contents, file) => {
             console.log(`└── ${colors.cyan(file)}:`);
             contents.split('\n').forEach(line => {
@@ -313,9 +307,7 @@ export const inspectCommand = async (
                 );
               }
 
-              chunks.forEach(chunk =>
-                console.log(colors.white('    | ' + chunk))
-              );
+              chunks.forEach(chunk => console.log('    | ' + chunk));
             });
             console.log();
           });

--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -273,12 +273,10 @@ export const iterateCommand = async (
     result.taskTitle = task.title;
 
     if (!options.json) {
-      console.log(colors.white.bold('Task Details'));
+      console.log(colors.bold('Task Details'));
       console.log(colors.gray('├── ID: ') + colors.cyan(task.id.toString()));
-      console.log(colors.gray('├── Task Title: ') + colors.white(task.title));
-      console.log(
-        colors.gray('├── Current Status: ') + colors.white(task.status)
-      );
+      console.log(colors.gray('├── Task Title: ') + task.title);
+      console.log(colors.gray('├── Current Status: ') + task.status);
       console.log(
         colors.gray('└── Instructions: ') + colors.green(finalInstructions)
       );
@@ -362,13 +360,11 @@ export const iterateCommand = async (
     // Skip confirmation and refinement instructions if --json flag is passed
     if (!options.json) {
       // Display the expanded iteration
-      console.log(colors.white.bold('Iteration:'));
+      console.log(colors.bold('Iteration:'));
       console.log(
         colors.gray('├── Instructions: ') + colors.cyan(expandedTask.title)
       );
-      console.log(
-        colors.gray('└── Details: ') + colors.white(expandedTask.description)
-      );
+      console.log(colors.gray('└── Details: ') + expandedTask.description);
     }
 
     // Check if we're in a git repository and setup worktree

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -157,9 +157,7 @@ export const listCommand = async (
     // Print header
     let headerRow = '';
     headers.forEach((header, index) => {
-      headerRow += colors.bold(
-        colors.white(header.padEnd(columnWidths[index]))
-      );
+      headerRow += colors.bold(header.padEnd(columnWidths[index]));
     });
     console.log(headerRow);
 
@@ -202,9 +200,7 @@ export const listCommand = async (
 
       let row = '';
       row += colors.cyan(task.id.toString().padEnd(columnWidths[0]));
-      row += colors.white(
-        truncateText(title, columnWidths[1] - 1).padEnd(columnWidths[1])
-      );
+      row += truncateText(title, columnWidths[1] - 1).padEnd(columnWidths[1]);
       row += colors.gray(agent.padEnd(columnWidths[2]));
       row += colorFunc(formatTaskStatus(taskStatus).padEnd(columnWidths[3])); // +10 for ANSI codes
       row += formatProgress(

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -116,8 +116,8 @@ export const logsCommand = async (
 
     // Display header
     if (!json) {
-      console.log(colors.white.bold(`Task ${numericTaskId} Logs`));
-      console.log(colors.gray('├── Title: ') + colors.white(task.title));
+      console.log(colors.bold(`Task ${numericTaskId} Logs`));
+      console.log(colors.gray('├── Title: ') + task.title);
       console.log(
         colors.gray('└── Iteration: ') + colors.cyan(`#${actualIteration}`)
       );
@@ -127,7 +127,7 @@ export const logsCommand = async (
 
     if (!json) {
       console.log('');
-      console.log(colors.white.bold('Execution Log\n'));
+      console.log(colors.bold('Execution Log\n'));
     }
 
     if (options.follow && !json) {

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -284,14 +284,12 @@ export const mergeCommand = async (
     jsonOutput.branchName = task.branchName;
 
     if (!options.json) {
-      console.log(colors.white.bold('Merge Task'));
+      console.log(colors.bold('Merge Task'));
       console.log(colors.gray('├── ID: ') + colors.cyan(task.id.toString()));
-      console.log(colors.gray('├── Title: ') + colors.white(task.title));
-      console.log(
-        colors.gray('├── Worktree: ') + colors.white(task.worktreePath)
-      );
-      console.log(colors.gray('├── Branch: ') + colors.white(task.branchName));
-      console.log(colors.gray('└── Status: ') + colors.white(task.status));
+      console.log(colors.gray('├── Title: ') + task.title);
+      console.log(colors.gray('├── Worktree: ') + task.worktreePath);
+      console.log(colors.gray('├── Branch: ') + task.branchName);
+      console.log(colors.gray('└── Status: ') + task.status);
     }
 
     if (task.isPushed()) {
@@ -496,7 +494,7 @@ export const mergeCommand = async (
             mergeConflicts.forEach((file, index) => {
               const isLast = index === mergeConflicts.length - 1;
               const connector = isLast ? '└──' : '├──';
-              console.log(colors.gray(connector), colors.white(file));
+              console.log(colors.gray(connector), file);
             });
           }
 
@@ -593,7 +591,7 @@ export const mergeCommand = async (
                 colors.gray('3. Run: git merge --continue')
               );
 
-              console.log(colors.white('\nIf you prefer to stop the process:'));
+              console.log('\nIf you prefer to stop the process:');
               console.log(colors.cyan(`└── 1. Run: git merge --abort`));
             }
             exitWithError(jsonOutput, options.json);

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -109,10 +109,10 @@ export const pushCommand = async (taskId: string, options: PushOptions) => {
 
       const colorFunc = statusColor(task.status);
 
-      console.log(colors.white.bold('Push task changes'));
+      console.log(colors.bold('Push task changes'));
       console.log(colors.gray('├── ID: ') + colors.cyan(task.id.toString()));
-      console.log(colors.gray('├── Title: ') + colors.white(task.title));
-      console.log(colors.gray('├── Branch: ') + colors.white(task.branchName));
+      console.log(colors.gray('├── Title: ') + task.title);
+      console.log(colors.gray('├── Branch: ') + task.branchName);
       console.log(colors.gray('└── Status: ') + colorFunc(task.status) + '\n');
     }
 

--- a/packages/cli/src/commands/reset.ts
+++ b/packages/cli/src/commands/reset.ts
@@ -33,7 +33,7 @@ export const resetCommand = async (
 
     console.log(colors.bold('\n🔄 Reset Task\n'));
     console.log(colors.gray('ID: ') + colors.cyan(taskId));
-    console.log(colors.gray('Title: ') + colors.white(task.title));
+    console.log(colors.gray('Title: ') + task.title);
     console.log(colors.gray('Status: ') + colors.yellow(task.status));
 
     if (existsSync(task.worktreePath)) {

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -139,9 +139,9 @@ export const restartCommand = async (
     }
 
     if (!json) {
-      console.log(colors.bold.white('Restarting Task'));
+      console.log(colors.bold('Restarting Task'));
       console.log(colors.gray('├── ID: ') + colors.cyan(task.id.toString()));
-      console.log(colors.gray('├── Title: ') + colors.white(task.title));
+      console.log(colors.gray('├── Title: ') + task.title);
       console.log(colors.gray('├── Status: ') + colors.red(task.status));
       console.log(colors.gray('├── Workspace: ') + colors.cyan(worktreePath));
       console.log(colors.gray('├── Branch: ') + colors.cyan(branchName));

--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -38,9 +38,9 @@ export const shellCommand = async (
 
     const colorFunc = statusColor(task.status);
 
-    console.log(colors.white.bold('Task details'));
+    console.log(colors.bold('Task details'));
     console.log(colors.gray('├── ID: ') + colors.cyan(task.id.toString()));
-    console.log(colors.gray('├── Title: ') + colors.white(task.title));
+    console.log(colors.gray('├── Title: ') + task.title);
     console.log(colors.gray('└── Status: ') + colorFunc(task.status) + '\n');
 
     // Check if worktree exists

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -53,9 +53,9 @@ export const stopCommand = async (
     const task = TaskDescription.load(numericTaskId);
 
     if (!json) {
-      console.log(colors.bold.white('Stopping Task'));
+      console.log(colors.bold('Stopping Task'));
       console.log(colors.gray('├── ID: ') + colors.cyan(task.id.toString()));
-      console.log(colors.gray('├── Title: ') + colors.white(task.title));
+      console.log(colors.gray('├── Title: ') + task.title);
       console.log(colors.gray('└── Status: ') + colors.yellow(task.status));
     }
 

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -205,10 +205,8 @@ export const startDockerExecution = async (
   const envVariables: string[] = agent.getEnvironmentVariables();
 
   if (!jsonMode) {
-    console.log(colors.white.bold('\n🐳 Starting Docker container:'));
-    console.log(
-      colors.gray('└── Container Name: ') + colors.white(containerName)
-    );
+    console.log(colors.bold('\n🐳 Starting Docker container:'));
+    console.log(colors.gray('└── Container Name: ') + containerName);
   }
 
   // Clean up any existing container with same name
@@ -481,10 +479,8 @@ export const taskCommand = async (
           );
           console.log(
             colors.gray('└── Body: ') +
-              colors.white(
-                issueData.body.substring(0, 100) +
-                  (issueData.body.length > 100 ? '...' : '')
-              )
+              issueData.body.substring(0, 100) +
+              (issueData.body.length > 100 ? '...' : '')
           );
         }
       } else {
@@ -633,13 +629,12 @@ export const taskCommand = async (
         } else {
           // Display the expanded task
           if (!json) {
-            console.log('\n' + colors.white.bold('Task Details:'));
+            console.log('\n' + colors.bold('Task Details:'));
             console.log(
               colors.gray('├── Title: ') + colors.cyan(taskData.title)
             );
             console.log(
-              colors.gray('└── Description: ') +
-                colors.white(taskData.description)
+              colors.gray('└── Description: ') + taskData.description
             );
           }
 
@@ -786,9 +781,9 @@ export const taskCommand = async (
     task.markInProgress();
 
     if (!json) {
-      console.log(colors.bold.white('\n🚀 Task Created'));
+      console.log(colors.bold('\n🚀 Task Created'));
       console.log(colors.gray('├── ID: ') + colors.cyan(task.id.toString()));
-      console.log(colors.gray('├── Title: ') + colors.white(task.title));
+      console.log(colors.gray('├── Title: ') + task.title);
       console.log(
         colors.gray('├── Workspace: ') + colors.cyan(task.worktreePath)
       );

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -34,9 +34,7 @@ export function createProgram(
         const commandName = actionCommand.name();
         if (!['init', 'mcp'].includes(commandName) && !ProjectConfig.exists()) {
           console.log(
-            colors.white(
-              `Rover is not initialized in this directory. The command you requested (\`${commandName}\`) was not executed.`
-            )
+            `Rover is not initialized in this directory. The command you requested (\`${commandName}\`) was not executed.`
           );
           console.log(
             `└── ${colors.gray('Project config (does not exist):')} rover.json`
@@ -110,9 +108,7 @@ export function createProgram(
           !UserSettings.exists()
         ) {
           console.log(
-            colors.white(
-              `Rover is not fully initialized in this directory. The command you requested (\`${commandName}\`) was not executed.`
-            )
+            `Rover is not fully initialized in this directory. The command you requested (\`${commandName}\`) was not executed.`
           );
           console.log(
             `├── ${colors.gray('Project config (exists):')} rover.json`

--- a/packages/cli/src/utils/display.ts
+++ b/packages/cli/src/utils/display.ts
@@ -28,7 +28,7 @@ export const showTips = (tips: string[], config: TipsConfig = {}) => {
 
   if (buildConfig.breakline) console.log('');
 
-  console.log(colors.white(`${buildConfig.emoji} ${buildConfig.title}:`));
+  console.log(`${buildConfig.emoji} ${buildConfig.title}:`);
 
   for (const tip of tips) {
     console.log(colors.gray(`   ${tip}`));


### PR DESCRIPTION
Removes hardcoded white text color from CLI output to improve readability across different terminal themes and configurations.

## Changes

- Removed `.white` color modifier from console output across CLI and agent packages
- Affected commands: task, shell, iterate, inspect, delete, diff, init, list, logs, merge, push, restart, stop
- Updated agent package output formatting

Closes #209