### PR TITLE
feat: add GitHub workflow to build and publish Docker images

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,84 @@
+name: Build and Publish Docker Image
+run-name: Build node image ${{ github.event.inputs.tag }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g., v1.0.0, latest)'
+        type: string
+        required: true
+        default: 'latest'
+      platforms:
+        description: 'Target platforms'
+        type: string
+        required: true
+        default: 'linux/amd64,linux/arm64'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Echo inputs
+        run: |
+          echo "Tag: $TAG"
+          echo "Platforms: $PLATFORMS"
+        env:
+          TAG: ${{ inputs.tag }}
+          PLATFORMS: ${{ inputs.platforms }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/node
+          tags: |
+            type=raw,value=${{ inputs.tag }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./images/node
+          file: ./images/node/Dockerfile
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Notify on Success
+        if: success()
+        env:
+          IMAGE_TAG: ${{ inputs.tag }}
+          IMAGE_URL: 'ghcr.io/${{ github.repository }}/node:${{ inputs.tag }}'
+        run: |
+          echo "✅ Successfully built and pushed Docker image"
+          echo "Image: ${IMAGE_URL}"
+          echo "Platforms: ${{ inputs.platforms }}"
+
+      - name: Notify on Failure
+        if: failure()
+        run: |
+          echo "❌ Failed to build or push Docker image"
+          echo "Please check the workflow logs for details"

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -11,4 +11,4 @@ RUN apk update && \
     wget -O /usr/local/bin/package-manager-mcp-server \
       https://github.com/endorhq/package-manager-mcp/releases/download/${PACKAGE_MANAGER_MCP_SERVER_VERSION}/package-manager-mcp-${ARCH_SUFFIX} && \
     chmod +s+x /usr/local/bin/package-manager-mcp-server
-COPY ./assets/sudoers /etc/sudoers.d/rover
+COPY ./assets/sudoers /etc/sudoers.d/agent

--- a/images/node/Dockerfile
+++ b/images/node/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:24-alpine
+ARG TARGETARCH
+ARG PACKAGE_MANAGER_MCP_SERVER_VERSION="v0.1.3"
+RUN apk update && \
+    apk add jq sudo && \
+    case ${TARGETARCH} in \
+      amd64) ARCH_SUFFIX="x86_64-unknown-linux-musl" ;; \
+      arm64) ARCH_SUFFIX="aarch64-unknown-linux-musl" ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    wget -O /usr/local/bin/package-manager-mcp-server \
+      https://github.com/endorhq/package-manager-mcp/releases/download/${PACKAGE_MANAGER_MCP_SERVER_VERSION}/package-manager-mcp-${ARCH_SUFFIX} && \
+    chmod +s+x /usr/local/bin/package-manager-mcp-server
+COPY ./assets/sudoers /etc/sudoers.d/rover

--- a/images/node/assets/sudoers
+++ b/images/node/assets/sudoers
@@ -1,0 +1,38 @@
+# Rover agent group; if there is no matching gid within the container
+# with the host gid, the `agent` group will be used.
+%agent ALL=(ALL) NOPASSWD: ALL
+
+# Original image group list at /etc/group. If the host user gid
+# matches with any of them, it will be able to use `sudo` normally
+# within the container.
+%adm ALL=(ALL) NOPASSWD: ALL
+%tty ALL=(ALL) NOPASSWD: ALL
+%disk ALL=(ALL) NOPASSWD: ALL
+%lp ALL=(ALL) NOPASSWD: ALL
+%kmem ALL=(ALL) NOPASSWD: ALL
+%wheel ALL=(ALL) NOPASSWD: ALL
+%floppy ALL=(ALL) NOPASSWD: ALL
+%mail ALL=(ALL) NOPASSWD: ALL
+%news ALL=(ALL) NOPASSWD: ALL
+%uucp ALL=(ALL) NOPASSWD: ALL
+%cron ALL=(ALL) NOPASSWD: ALL
+%audio ALL=(ALL) NOPASSWD: ALL
+%cdrom ALL=(ALL) NOPASSWD: ALL
+%dialout ALL=(ALL) NOPASSWD: ALL
+%ftp ALL=(ALL) NOPASSWD: ALL
+%sshd ALL=(ALL) NOPASSWD: ALL
+%input ALL=(ALL) NOPASSWD: ALL
+%tape ALL=(ALL) NOPASSWD: ALL
+%video ALL=(ALL) NOPASSWD: ALL
+%netdev ALL=(ALL) NOPASSWD: ALL
+%kvm ALL=(ALL) NOPASSWD: ALL
+%games ALL=(ALL) NOPASSWD: ALL
+%shadow ALL=(ALL) NOPASSWD: ALL
+%www-data ALL=(ALL) NOPASSWD: ALL
+%users ALL=(ALL) NOPASSWD: ALL
+%ntp ALL=(ALL) NOPASSWD: ALL
+%abuild ALL=(ALL) NOPASSWD: ALL
+%utmp ALL=(ALL) NOPASSWD: ALL
+%ping ALL=(ALL) NOPASSWD: ALL
+%nogroup ALL=(ALL) NOPASSWD: ALL
+%nobody ALL=(ALL) NOPASSWD: ALL


### PR DESCRIPTION
Add a new GitHub Actions workflow that enables manual building and publishing of the Rover Docker image to GitHub Container Registry. This workflow supports multi-platform builds and versioned image tagging.

Related to #194.

## Changes

- Created `.github/workflows/build-image.yml` workflow with manual dispatch trigger supporting configurable image tags and target platforms
- Added `images/node/Dockerfile` to build Node.js-based container image with package-manager-mcp-server pre-installed
- Added `images/node/assets/sudoers` configuration to enable passwordless sudo for common groups within containers
- Implemented multi-architecture support for amd64 and arm64 platforms using QEMU and Docker Buildx
- Configured workflow to publish images to `ghcr.io/<repository>/node` with GitHub Container Registry authentication

## Notes

The workflow uses `workflow_dispatch` for manual triggering, allowing maintainers to control when new images are built and published. The default tag is `latest` but can be customized for version-specific releases.

The Dockerfile installs package-manager-mcp-server v0.1.3 and configures sudo permissions to match the host user's group permissions, ensuring smooth operation within Rover's containerized environment.