### PR TITLE
feat: add config mcp command to agent CLI

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_INSTALL_VERSION,
   installCommand,
 } from './commands/install.js';
+import { addConfigCommands } from './commands/config/index.js';
 
 // Common types
 export interface CommandOutput {
@@ -53,7 +54,7 @@ program
     'Agent tool to use. It overrides defaults, but prioritize step tools if available.'
   )
   .option(
-    '--agent-model <agent>',
+    '--agent-model <model>',
     'Agent model to use. It overrides defaults, but prioritize step tools if available.'
   )
   .option(
@@ -89,6 +90,9 @@ program
     DEFAULT_INSTALL_DIRECTORY
   )
   .action(installCommand);
+
+// Add the config commands
+addConfigCommands(program);
 
 program.parse(process.argv);
 

--- a/packages/agent/src/commands/config/index.ts
+++ b/packages/agent/src/commands/config/index.ts
@@ -1,0 +1,47 @@
+// Set the different subcommands for the config command.
+// These commands changes the configuration for the different agents.
+
+import { Argument, Command } from 'commander';
+import { DEFAULT_MCP_TRANSPORT, mcpInstallCommand } from './mcp.js';
+
+// Simple helper to collect multiple options using the same key
+const collect = (value: string, previous: string[]) => {
+  return previous.concat([value]);
+};
+
+export const addConfigCommands = (program: Command) => {
+  // Add the different commands
+  const config = program
+    .command('config')
+    .description('Configure Agent capabilities');
+
+  config
+    .command('mcp')
+    .description('Configure an MCP server globally for a given agent')
+    .addArgument(
+      new Argument(
+        '<agent>',
+        'AI Coding Agent to add the MCP server to'
+      ).choices(['claude', 'codex', 'gemini', 'qwen'])
+    )
+    .argument('<name>', 'The name of the MCP server')
+    .argument('<commandOrUrl>', 'The command or URL to run this MCP server')
+    .option(
+      '-t, --transport <transport>',
+      'The transport type (sse, stdio, http)',
+      DEFAULT_MCP_TRANSPORT
+    )
+    .option(
+      '-e, --env <env>',
+      'Set an environment variable for the MCP server using KEY=VALUE format',
+      collect,
+      []
+    )
+    .option(
+      '-H, --header <header>',
+      'Set HTTP headers for SSE and HTTP transports',
+      collect,
+      []
+    )
+    .action(mcpInstallCommand);
+};

--- a/packages/agent/src/commands/config/mcp.ts
+++ b/packages/agent/src/commands/config/mcp.ts
@@ -1,0 +1,81 @@
+import colors from 'ansi-colors';
+import { CommandOutput } from '../../cli.js';
+import { createAgent } from '../../lib/agents/index.js';
+import ora from 'ora';
+
+export const DEFAULT_MCP_TRANSPORT = 'stdio';
+
+interface ConfigMCPCommandOptions {
+  // MCP transport protocol
+  transport: string;
+  // Environment variables
+  env: string[];
+  // HTTP Headers for SSE and HTTP
+  header: string[];
+}
+
+interface ConfigMCPCommandOutput extends CommandOutput {}
+
+/**
+ * Install an AI Coding Tool and configure the required credentials to run it
+ */
+export const mcpInstallCommand = async (
+  agentName: string,
+  mcpName: string,
+  commandOrUrl: string,
+  options: ConfigMCPCommandOptions
+) => {
+  const output: ConfigMCPCommandOutput = {
+    success: false,
+  };
+
+  const spinner = ora({
+    text: `Installing MCP server`,
+    spinner: 'dots2',
+  });
+
+  try {
+    console.log(colors.bold('MCP Server to install'));
+    console.log(colors.gray('├── Agent: ') + agentName);
+    console.log(colors.gray('├── MCP Name: ') + colors.cyan(mcpName));
+    console.log(
+      colors.gray('├── MCP Command or URL: ') + colors.cyan(commandOrUrl)
+    );
+    console.log(colors.gray('└── MCP Transport: ') + options.transport);
+
+    console.log();
+    spinner.text = `Checking agent`;
+    spinner.start();
+
+    const agent = createAgent(agentName);
+    const installed = await agent.isInstalled();
+
+    if (!installed) {
+      output.error = `The ${agent.name} is not installed in the system. Install it first`;
+    } else {
+      spinner.text = `Installing MCP server in ${agent.name}`;
+
+      // We can install the MCP server
+      // These methods can throw errors
+      await agent.configureMCP(
+        mcpName,
+        commandOrUrl,
+        options.transport,
+        options.env,
+        options.header
+      );
+
+      spinner.succeed('Installation completed successfully');
+      output.success = true;
+    }
+  } catch (err) {
+    console.log(err);
+    spinner.fail('The MCP server was not installed');
+    output.success = false;
+    output.error = err instanceof Error ? err.message : `${err}`;
+  }
+
+  if (!output.success) {
+    console.log(colors.red(`\n✗ ${output.error}`));
+  }
+};

--- a/packages/agent/src/commands/config/mcp.ts
+++ b/packages/agent/src/commands/config/mcp.ts
@@ -69,7 +69,6 @@ export const mcpInstallCommand = async (
       output.success = true;
     }
   } catch (err) {
-    console.log(err);
     spinner.fail('The MCP server was not installed');
     output.success = false;
     output.error = err instanceof Error ? err.message : `${err}`;

--- a/packages/agent/src/lib/agents/base.ts
+++ b/packages/agent/src/lib/agents/base.ts
@@ -1,10 +1,11 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import colors from 'ansi-colors';
-import { launchSync } from 'rover-common';
+import { launch, launchSync } from 'rover-common';
 import { Agent, AgentCredentialFile, ValidationResult } from './types.js';
 
 export abstract class BaseAgent implements Agent {
   abstract name: string;
+  abstract binary: string;
   version: string;
 
   constructor(version: string = 'latest') {
@@ -84,5 +85,11 @@ export abstract class BaseAgent implements Agent {
         );
       }
     }
+  }
+
+  async isInstalled(): Promise<boolean> {
+    const result = await launch(this.binary, ['--version']);
+
+    return result.exitCode === 0;
   }
 }

--- a/packages/agent/src/lib/agents/base.ts
+++ b/packages/agent/src/lib/agents/base.ts
@@ -15,6 +15,13 @@ export abstract class BaseAgent implements Agent {
   abstract getRequiredCredentials(): AgentCredentialFile[];
   abstract getInstallCommand(): string;
   abstract copyCredentials(targetDir: string): Promise<void>;
+  abstract configureMCP(
+    name: string,
+    commandOrUrl: string,
+    transport: string,
+    envs: string[],
+    headers: string[]
+  ): Promise<void>;
 
   protected ensureDirectory(dirPath: string): void {
     try {

--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -97,7 +97,7 @@ export class ClaudeAgent extends BaseAgent {
 
     headers.forEach(header => {
       if (/[\w\-]+\s*:\s*\w+/.test(header)) {
-        args.push('-H', `${header.replaceAll(' ', '\\ ')}`);
+        args.push('-H', header);
       } else {
         console.log(
           colors.yellow(` Invalid ${header} header. Use "KEY: VALUE" format`)

--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -24,7 +24,7 @@ export class ClaudeAgent extends BaseAgent {
       {
         path: '/.credentials.json',
         description: 'Claude credentials',
-        required: false, // It's not required when using env variables
+        required: true, // It's not required when using env variables
       },
     ];
   }

--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -22,7 +22,7 @@ export class ClaudeAgent extends BaseAgent {
       {
         path: '/.credentials.json',
         description: 'Claude credentials',
-        required: true,
+        required: false, // It's not required when using env variables
       },
     ];
   }

--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -78,6 +78,11 @@ export class ClaudeAgent extends BaseAgent {
   ): Promise<void> {
     const args = ['mcp', 'add', '--transport', transport];
 
+    // Prepend this to other options to avoid issues with the command.
+    // Since execa add quotes to '--env=A=B', if we add the name after,
+    // the Claude CLI ignores it.
+    args.push(name);
+
     envs.forEach(env => {
       if (/\w+=\w+/.test(env)) {
         args.push(`--env=${env}`);
@@ -99,8 +104,6 @@ export class ClaudeAgent extends BaseAgent {
         );
       }
     });
-
-    args.push(name);
 
     // @see https://docs.claude.com/en/docs/claude-code/mcp#installing-mcp-servers
     if (transport === 'stdio') {

--- a/packages/agent/src/lib/agents/codex.ts
+++ b/packages/agent/src/lib/agents/codex.ts
@@ -3,9 +3,11 @@ import { join } from 'node:path';
 import colors from 'ansi-colors';
 import { AgentCredentialFile } from './types.js';
 import { BaseAgent } from './base.js';
+import { launch } from 'rover-common';
 
 export class CodexAgent extends BaseAgent {
   name = 'Codex';
+  binary = 'codex';
 
   getInstallCommand(): string {
     const packageSpec = `@openai/codex@${this.version}`;
@@ -44,5 +46,49 @@ export class CodexAgent extends BaseAgent {
     }
 
     console.log(colors.green(`✓ ${this.name} credentials copied successfully`));
+  }
+
+  async configureMCP(
+    name: string,
+    commandOrUrl: string,
+    transport: string,
+    envs: string[],
+    headers: string[]
+  ): Promise<void> {
+    const args = ['mcp', 'add'];
+
+    if (transport !== 'stdio') {
+      throw new Error(`${this.name} only supports stdio transport`);
+    }
+
+    envs.forEach(env => {
+      if (/\w+=\w+/.test(env)) {
+        args.push(`--env=${env}`);
+      } else {
+        console.log(
+          colors.yellow(
+            ` Invalid ${env} environment variable. Use KEY=VALUE format`
+          )
+        );
+      }
+    });
+
+    if (headers.length > 0) {
+      console.log(
+        colors.yellow(
+          ` ${this.name} does not support HTTP or SSE servers. Ignoring headers.`
+        )
+      );
+    }
+
+    args.push(name, commandOrUrl);
+
+    const result = await launch(this.binary, args);
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `There was an error adding the ${name} MCP server to ${this.name}.\n${result.stderr}`
+      );
+    }
   }
 }

--- a/packages/agent/src/lib/agents/codex.ts
+++ b/packages/agent/src/lib/agents/codex.ts
@@ -17,7 +17,7 @@ export class CodexAgent extends BaseAgent {
       {
         path: '/.codex/auth.json',
         description: 'Codex authentication',
-        required: true,
+        required: false,
       },
       {
         path: '/.codex/config.json',

--- a/packages/agent/src/lib/agents/gemini.ts
+++ b/packages/agent/src/lib/agents/gemini.ts
@@ -82,7 +82,7 @@ export class GeminiAgent extends BaseAgent {
 
     envs.forEach(env => {
       if (/\w+=\w+/.test(env)) {
-        args.push(`--env = ${env}`);
+        args.push(`--env=${env}`);
       } else {
         console.log(
           colors.yellow(
@@ -94,10 +94,10 @@ export class GeminiAgent extends BaseAgent {
 
     headers.forEach(header => {
       if (/[\w\-]+\s*:\s*\w+/.test(header)) {
-        args.push('-H', `${header.replaceAll(' ', '\\ ')}`);
+        args.push('-H', header);
       } else {
         console.log(
-          colors.yellow(` Invalid ${header} header.Use "KEY: VALUE" format`)
+          colors.yellow(` Invalid ${header} header. Use "KEY: VALUE" format`)
         );
       }
     });

--- a/packages/agent/src/lib/agents/gemini.ts
+++ b/packages/agent/src/lib/agents/gemini.ts
@@ -3,9 +3,12 @@ import { join } from 'node:path';
 import colors from 'ansi-colors';
 import { AgentCredentialFile } from './types.js';
 import { BaseAgent } from './base.js';
+import { launch } from 'rover-common';
+import { L } from 'vitest/dist/chunks/reporters.nr4dxCkA.js';
 
 export class GeminiAgent extends BaseAgent {
   name = 'Gemini';
+  binary = 'gemini';
 
   getInstallCommand(): string {
     const packageSpec = `@google/gemini-cli@${this.version}`;
@@ -49,5 +52,62 @@ export class GeminiAgent extends BaseAgent {
     }
 
     console.log(colors.green(`✓ ${this.name} credentials copied successfully`));
+  }
+
+  async configureMCP(
+    name: string,
+    commandOrUrl: string,
+    transport: string,
+    envs: string[],
+    headers: string[]
+  ): Promise<void> {
+    const args = [
+      'mcp',
+      'add',
+      '--transport',
+      transport,
+      '--trust', // Trust the server (bypass all tool call confirmation prompts)
+      '--scope',
+      'user', // Save it at user level to prevent adding files to the repo
+    ];
+
+    // Some fun stuff. In Gemini, the --env options must be at the end of the command.
+    // Even after the arguments for the target MCP command.
+    //
+    // This works: gemini mcp add rover-mcp npx -y @endorhq/rover mcp -e MY_VAR=VALUE
+    // This does not work: gemini mcp add -e MY_VAR=VALUE rover-mcp npx -y @endorhq/rover mcp
+    //
+    // @https://github.com/google-gemini/gemini-cli/issues/10387
+    args.push(name, commandOrUrl);
+
+    envs.forEach(env => {
+      if (/\w+=\w+/.test(env)) {
+        args.push(`--env = ${env}`);
+      } else {
+        console.log(
+          colors.yellow(
+            ` Invalid ${env} environment variable. Use KEY = VALUE format`
+          )
+        );
+      }
+    });
+
+    headers.forEach(header => {
+      if (/[\w\-]+\s*:\s*\w+/.test(header)) {
+        args.push('-H', `${header.replaceAll(' ', '\\ ')}`);
+      } else {
+        console.log(
+          colors.yellow(` Invalid ${header} header.Use "KEY: VALUE" format`)
+        );
+      }
+    });
+
+    const result = await launch(this.binary, args);
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `There was an error adding the ${name} MCP server to ${this.name}.\n${result.stderr}`
+      );
+    }
   }
 }

--- a/packages/agent/src/lib/agents/qwen.ts
+++ b/packages/agent/src/lib/agents/qwen.ts
@@ -81,7 +81,7 @@ export class QwenAgent extends BaseAgent {
 
     envs.forEach(env => {
       if (/\w+=\w+/.test(env)) {
-        args.push(`--env = ${env}`);
+        args.push(`--env=${env}`);
       } else {
         console.log(
           colors.yellow(
@@ -93,10 +93,10 @@ export class QwenAgent extends BaseAgent {
 
     headers.forEach(header => {
       if (/[\w\-]+\s*:\s*\w+/.test(header)) {
-        args.push('-H', `${header.replaceAll(' ', '\\ ')}`);
+        args.push('-H', header);
       } else {
         console.log(
-          colors.yellow(` Invalid ${header} header.Use "KEY: VALUE" format`)
+          colors.yellow(` Invalid ${header} header. Use "KEY: VALUE" format`)
         );
       }
     });

--- a/packages/agent/src/lib/agents/qwen.ts
+++ b/packages/agent/src/lib/agents/qwen.ts
@@ -3,9 +3,11 @@ import { join } from 'node:path';
 import colors from 'ansi-colors';
 import { AgentCredentialFile } from './types.js';
 import { BaseAgent } from './base.js';
+import { launch } from 'rover-common';
 
 export class QwenAgent extends BaseAgent {
   name = 'Qwen';
+  binary = 'qwen';
 
   getInstallCommand(): string {
     const packageSpec = `@qwen-code/qwen-code@${this.version}`;
@@ -49,5 +51,62 @@ export class QwenAgent extends BaseAgent {
     }
 
     console.log(colors.green(`✓ ${this.name} credentials copied successfully`));
+  }
+
+  async configureMCP(
+    name: string,
+    commandOrUrl: string,
+    transport: string,
+    envs: string[],
+    headers: string[]
+  ): Promise<void> {
+    const args = [
+      'mcp',
+      'add',
+      '--transport',
+      transport,
+      '--trust', // Trust the server (bypass all tool call confirmation prompts)
+      '--scope',
+      'user', // Save it at user level to prevent adding files to the repo
+    ];
+
+    // Some fun stuff. In Gemini, the --env options must be at the end of the command.
+    // Even after the arguments for the target MCP command.
+    //
+    // This works: gemini mcp add rover-mcp npx -y @endorhq/rover mcp -e MY_VAR=VALUE
+    // This does not work: gemini mcp add -e MY_VAR=VALUE rover-mcp npx -y @endorhq/rover mcp
+    //
+    // @https://github.com/google-gemini/gemini-cli/issues/10387
+    args.push(name, commandOrUrl);
+
+    envs.forEach(env => {
+      if (/\w+=\w+/.test(env)) {
+        args.push(`--env = ${env}`);
+      } else {
+        console.log(
+          colors.yellow(
+            ` Invalid ${env} environment variable.Use KEY = VALUE format`
+          )
+        );
+      }
+    });
+
+    headers.forEach(header => {
+      if (/[\w\-]+\s*:\s*\w+/.test(header)) {
+        args.push('-H', `${header.replaceAll(' ', '\\ ')}`);
+      } else {
+        console.log(
+          colors.yellow(` Invalid ${header} header.Use "KEY: VALUE" format`)
+        );
+      }
+    });
+
+    const result = await launch(this.binary, args);
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `There was an error adding the ${name} MCP server to ${this.name}.\n${result.stderr}`
+      );
+    }
   }
 }

--- a/packages/agent/src/lib/agents/types.ts
+++ b/packages/agent/src/lib/agents/types.ts
@@ -17,5 +17,13 @@ export interface Agent {
   validateCredentials(): ValidationResult;
   getInstallCommand(): string;
   install(): Promise<void>;
+  configureMCP(
+    name: string,
+    commandOrUrl: string,
+    transport: string,
+    envs: string[],
+    headers: string[]
+  ): Promise<void>;
   copyCredentials(targetDir: string): Promise<void>;
+  isInstalled(): Promise<boolean>;
 }

--- a/packages/common/src/os.ts
+++ b/packages/common/src/os.ts
@@ -1,18 +1,12 @@
-import { execa, execaSync } from 'execa';
+import { execa, execaSync, parseCommandString } from 'execa';
 
-import type {
-  Options,
-  Result,
-  SyncOptions,
-  SyncResult,
-  StdoutStderrOption,
-} from 'execa';
+import type { Options, Result, SyncOptions, SyncResult } from 'execa';
 export type { Options, Result, SyncOptions, SyncResult };
 
 import colors from 'ansi-colors';
 import { Git } from './git.js';
 
-import { PROJECT_CONFIG_FILE, VERBOSE } from './index.js';
+import { VERBOSE } from './index.js';
 
 export type LaunchOptions = Options & {
   mightLogSensitiveInformation?: boolean;
@@ -88,11 +82,41 @@ const shouldAddLogging = (stream: string, options?: Options | SyncOptions) => {
   return !(streamArrayInherit || streamInherit);
 };
 
+/**
+ * Run a specific command with the arguments and return an object with the result.
+ * The command and args get converted in the a template string for proper escaping.
+ *
+ * Initially, we were passing a command + args[] to the execa method, but it was
+ * causing some escaping error. For example, if you pass:
+ *
+ * npx binary -- another-command test
+ *
+ * Using execa('npx', ['binary', '--', 'another-command', 'test']), the argument after
+ * -- gets incorrectly quoted: npx binary -- 'another-command test'.
+ *
+ * To avoid this issue, we use the parseCommandString + template strings.
+ *
+ * We found another corner case related to environment variables options like
+ * `-e ENV=VALUE`. Execa escapes the 'ENV=VALUE' string regardless you use options
+ * like { shell: true }. For those, you must use the long syntax: `--env=ENV=VALUE`.
+ *
+ * @see https://github.com/sindresorhus/execa/blob/main/docs/escaping.md
+ * @see https://github.com/sindresorhus/execa/blob/main/docs/shell.md
+ *
+ * @param command the command to run
+ * @param args arguments to pass to the command
+ * @param options Execa options to modify the behavior of the spawn
+ * @returns An Execa object with the result
+ */
 export function launch(
   command: string,
   args?: ReadonlyArray<string>,
   options?: LaunchOptions
 ): ReturnType<typeof execa> {
+  const parsedCommand = parseCommandString(
+    `${command} ${(args || []).join(' ')}`
+  );
+
   if (VERBOSE) {
     const now = new Date();
     console.error(
@@ -150,17 +174,53 @@ export function launch(
       } as Options;
     }
 
-    return execa(command, args, newOpts);
+    // Use template string as array format quotes arguments even when using shell
+    return execa(newOpts)`${parsedCommand}`;
   }
 
-  return execa(command, args, options);
+  if (options) {
+    return execa(options)`${parsedCommand}`;
+  } else {
+    return execa`${parsedCommand}`;
+  }
 }
 
+/**
+ * Run a specific command with the arguments and return an object with the result.
+ * The command and args get converted in the a template string for proper escaping.
+ * All this process run synchronously.
+ *
+ * Initially, we were passing a command + args[] to the execa method, but it was
+ * causing some escaping error. For example, if you pass:
+ *
+ * npx binary -- another-command test
+ *
+ * Using execa('npx', ['binary', '--', 'another-command', 'test']), the argument after
+ * -- gets incorrectly quoted: npx binary -- 'another-command test'.
+ *
+ * To avoid this issue, we use the parseCommandString + template strings.
+ *
+ * We found another corner case related to environment variables options like
+ * `-e ENV=VALUE`. Execa escapes the 'ENV=VALUE' string regardless you use options
+ * like { shell: true }. For those, you must use the long syntax: `--env=ENV=VALUE`.
+ *
+ * @see https://github.com/sindresorhus/execa/blob/main/docs/escaping.md
+ * @see https://github.com/sindresorhus/execa/blob/main/docs/shell.md
+ *
+ * @param command the command to run
+ * @param args arguments to pass to the command
+ * @param options Execa options to modify the behavior of the spawn
+ * @returns An Execa object with the result
+ */
 export function launchSync(
   command: string,
   args?: ReadonlyArray<string>,
   options?: LaunchSyncOptions
 ): ReturnType<typeof execaSync> {
+  const parsedCommand = parseCommandString(
+    `${command} ${(args || []).join(' ')}`
+  );
+
   if (VERBOSE) {
     const now = new Date();
     console.error(
@@ -218,7 +278,13 @@ export function launchSync(
       } as SyncOptions;
     }
 
-    return execaSync(command, args, newOpts);
+    // Use template string as array format quotes arguments even when using shell
+    return execaSync(newOpts)`${parsedCommand}`;
   }
-  return execaSync(command, args, options);
+
+  if (options) {
+    return execaSync(options)`${parsedCommand}`;
+  } else {
+    return execaSync`${parsedCommand}`;
+  }
 }

--- a/packages/common/src/os.ts
+++ b/packages/common/src/os.ts
@@ -113,9 +113,12 @@ export function launch(
   args?: ReadonlyArray<string>,
   options?: LaunchOptions
 ): ReturnType<typeof execa> {
-  const parsedCommand = parseCommandString(
-    `${command} ${(args || []).join(' ')}`
-  );
+  const argsWithSpacing = (args || [])
+    .map(arg => {
+      return arg.replaceAll(' ', '\\ ');
+    })
+    .join(' ');
+  const parsedCommand = parseCommandString(`${command} ${argsWithSpacing}`);
 
   if (VERBOSE) {
     const now = new Date();
@@ -217,9 +220,12 @@ export function launchSync(
   args?: ReadonlyArray<string>,
   options?: LaunchSyncOptions
 ): ReturnType<typeof execaSync> {
-  const parsedCommand = parseCommandString(
-    `${command} ${(args || []).join(' ')}`
-  );
+  const argsWithSpacing = (args || [])
+    .map(arg => {
+      return arg.replaceAll(' ', '\\ ');
+    })
+    .join(' ');
+  const parsedCommand = parseCommandString(`${command} ${argsWithSpacing}`);
 
   if (VERBOSE) {
     const now = new Date();


### PR DESCRIPTION
Add a new `rover-agent config mcp` command that allows users to configure MCP (Model Context Protocol) servers globally for different AI coding agents (Claude, Codex, Gemini, and Qwen). This enhancement streamlines the setup process by providing a unified interface to add MCP servers across all supported agents.

Related to #217

# Changes

- Added `config` command group with `mcp` subcommand to the agent CLI in `cli.ts`
- Created `mcp.ts` implementing the MCP installation logic with validation and error handling
- Implemented `configureMCP()` for all four agents (Claude, Codex, Gemini, Qwen) with agent-specific command formatting
- Added `isInstalled()` method to `BaseAgent` class to verify agent availability before configuration
- Marked credential files as non-required for Claude and Codex agents since they support alternative authentication via environment variables
- Updated `launch()` and `launchSync()` functions to use template strings with `parseCommandString()` for proper argument escaping, fixing issues with `--` argument separators and environment variable options

# Notes

The command supports multiple transport types (stdio, sse, http) and allows configuration of environment variables and HTTP headers per MCP server. Each agent implementation handles transport-specific requirements differently (e.g., Codex only supports stdio, while Claude and Gemini support all three).

The refactoring of `launch()` and `launchSync()` resolves escaping issues when passing arguments with special syntax like `npx binary -- command` and environment variable options like `-e ENV=VALUE`.

# Manual tests

```plain
$ node ./dist/cli.js config mcp -e API_KEY=MOCK -H "X-Auth-Wololo: Bearer" gemini context7 "npx -y @upstash/context7-mcp --api-key YOUR_API_KEY"
MCP Server to install
├── Agent: gemini
├── MCP Name: context7
├── MCP Command or URL: npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
└── MCP Transport: stdio

✔ Installation completed successfully

$ gemini mcp list
Configured MCP servers:

✓ context7: npx -y @upstash/context7-mcp --api-key YOUR_API_KEY (stdio) - Connected

$ node ./dist/cli.js config mcp -e API_KEY=MOCK -H "X-Auth-Wololo: Bearer" claude context7 "npx -y @upstash/context7-mcp --api-key YOUR_API_KEY"
MCP Server to install
├── Agent: claude
├── MCP Name: context7
├── MCP Command or URL: npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
└── MCP Transport: stdio

✔ Installation completed successfully

$ claude mcp list
Checking MCP server health...

context7: npx -y @upstash/context7-mcp --api-key YOUR_API_KEY - ✓ Connected

$ node ./dist/cli.js config mcp -e API_KEY=MOCK -H "X-Auth-Wololo: Bearer Token" qwen context7 "npx -y @upstash/context7-mcp --api-key YOUR_API_KEY"
MCP Server to install
├── Agent: qwen
├── MCP Name: context7
├── MCP Command or URL: npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
└── MCP Transport: stdio

✔ Installation completed successfully

$ qwen mcp list
Configured MCP servers:

✓ context7: npx -y @upstash/context7-mcp --api-key YOUR_API_KEY (stdio) - Connected

$ node ./dist/cli.js config mcp -e API_KEY=MOCK -H "X-Auth-Wololo: Bearer" codex context7 "npx -y @upstash/context7-mcp --api-key YOUR_API_KEY"
MCP Server to install
├── Agent: codex
├── MCP Name: context7
├── MCP Command or URL: npx -y @upstash/context7-mcp --api-key YOUR_API_KEY
└── MCP Transport: stdio

⣽ Checking agent Codex does not support HTTP or SSE servers. Ignoring headers.
✔ Installation completed successfully

$ codex mcp list
Name      Command  Args                                             Env
context7  npx      -y @upstash/context7-mcp --api-key YOUR_API_KEY  API_KEY=MOCK
```