### PR TITLE
chore: launch WSL on Windows with rover shell

### DIFF
--- a/images/node/assets/1-sudoers-setup
+++ b/images/node/assets/1-sudoers-setup
@@ -5,6 +5,10 @@
 # Original image group list at /etc/group. If the host user gid
 # matches with any of them, it will be able to use `sudo` normally
 # within the container.
+%root ALL=(ALL) NOPASSWD: ALL
+%bin ALL=(ALL) NOPASSWD: ALL
+%daemon ALL=(ALL) NOPASSWD: ALL
+%sys ALL=(ALL) NOPASSWD: ALL
 %adm ALL=(ALL) NOPASSWD: ALL
 %tty ALL=(ALL) NOPASSWD: ALL
 %disk ALL=(ALL) NOPASSWD: ALL
@@ -36,3 +40,4 @@
 %ping ALL=(ALL) NOPASSWD: ALL
 %nogroup ALL=(ALL) NOPASSWD: ALL
 %nobody ALL=(ALL) NOPASSWD: ALL
+%node ALL=(ALL) NOPASSWD: ALL

--- a/images/node/assets/2-sudoers-cleanup
+++ b/images/node/assets/2-sudoers-cleanup
@@ -5,6 +5,10 @@
 # Original image group list at /etc/group. If the host user gid
 # matches with any of them, it will be able to use `sudo` normally
 # within the container.
+%root ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
+%bin ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
+%daemon ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
+%sys ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
 %adm ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
 %tty ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
 %disk ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
@@ -36,3 +40,4 @@
 %ping ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
 %nogroup ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
 %nobody ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee
+%node ALL=(ALL) NOPASSWD: /bin/chown,/bin/cp,/bin/mv,/usr/bin/tee

--- a/packages/cli/src/lib/entrypoint.sh
+++ b/packages/cli/src/lib/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Template file for the entrypoint to run the agents and the workflow.
-# The purpose of this file is to install all required elements and 
+# The purpose of this file is to install all required elements and
 # prepare the agent to run.
 #
 # @see https://github.com/sindresorhus/pupa

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -65,7 +65,7 @@ export class SetupBuilder {
 
     // Write script to file
     const scriptPath = join(this.taskDir, 'entrypoint.sh');
-    writeFileSync(scriptPath, scriptContent, 'utf8');
+    writeFileSync(scriptPath, scriptContent.replace(/\r\n/g, '\n'), 'utf8');
 
     // Make script executable
     chmodSync(scriptPath, 0o755);

--- a/packages/common/src/os.ts
+++ b/packages/common/src/os.ts
@@ -113,12 +113,15 @@ export function launch(
   args?: ReadonlyArray<string>,
   options?: LaunchOptions
 ): ReturnType<typeof execa> {
-  const argsWithSpacing = (args || [])
+  const commandWithMaybeSpacing = command.replaceAll(' ', '\\ ');
+  const argsWithMaybeSpacing = (args || [])
     .map(arg => {
       return arg.replaceAll(' ', '\\ ');
     })
     .join(' ');
-  const parsedCommand = parseCommandString(`${command} ${argsWithSpacing}`);
+  const parsedCommand = parseCommandString(
+    `${commandWithMaybeSpacing} ${argsWithMaybeSpacing}`
+  );
 
   if (VERBOSE) {
     const now = new Date();
@@ -220,12 +223,15 @@ export function launchSync(
   args?: ReadonlyArray<string>,
   options?: LaunchSyncOptions
 ): ReturnType<typeof execaSync> {
-  const argsWithSpacing = (args || [])
+  const commandWithMaybeSpacing = command.replaceAll(' ', '\\ ');
+  const argsWithMaybeSpacing = (args || [])
     .map(arg => {
       return arg.replaceAll(' ', '\\ ');
     })
     .join(' ');
-  const parsedCommand = parseCommandString(`${command} ${argsWithSpacing}`);
+  const parsedCommand = parseCommandString(
+    `${commandWithMaybeSpacing} ${argsWithMaybeSpacing}`
+  );
 
   if (VERBOSE) {
     const now = new Date();


### PR DESCRIPTION
Fixes: #227
Fixes: #228

Fixes Docker container execution on Windows by properly handling UID/GID detection and providing fallback values. On Windows, the native `userInfo()` function returns `-1` for both UID and GID, which causes permission issues when running containers. This change detects when UID/GID cannot be retrieved and sets sensible defaults.

Additionally, this adds support for launching WSL shells and improves shell detection across platforms.

## Changes

- Set fallback UID/GID to `1000` when detection fails on Windows (instead of using `-1`)
- Refactored `etcPasswdWithCurrentUser()` and `etcGroupWithCurrentGroup()` to accept user info as parameter for better testability
- Added comprehensive shell detection for Windows (WSL → PowerShell Core → PowerShell → cmd.exe)
- Added missing sudoers entries for common system groups (`root`, `bin`, `daemon`, `sys`, `node`) in Docker image
- Fixed command parsing in `launch()` and `launchSync()` to handle spaces in command names
- Normalized line endings in entrypoint script to Unix format (`\n`)
- Bumped agent Docker image to `v1.3.0`

## Notes

The UID/GID fallback of `1000` is chosen because it's a common unprivileged user ID on Linux systems. This ensures the container runs with appropriate permissions even when the host system doesn't provide meaningful UID/GID values.