### PR TITLE
chore(gemini): do not require user_id

### DIFF
--- a/packages/agent/src/lib/agents/gemini.ts
+++ b/packages/agent/src/lib/agents/gemini.ts
@@ -30,7 +30,7 @@ export class GeminiAgent extends BaseAgent {
       {
         path: '/.gemini/user_id',
         description: 'Gemini user ID',
-        required: true,
+        required: false,
       },
     ];
   }


### PR DESCRIPTION
On the environment where I was trying the Fedora fix included in https://github.com/endorhq/rover/pull/232, I realized starting gemini was failing because of a missing `user_id` in gemini's configuration directory. However, this file is not really required as far as I can see.

It is working as expected without this file.