### PR TITLE
chore: add selinux mount options for workspace volume

### DIFF
--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -89,7 +89,7 @@ export const shellCommand = async (
           '--name',
           containerName,
           '-v',
-          `${task.worktreePath}:/workspace:rw`,
+          `${task.worktreePath}:/workspace:Z,rw`,
           '-w',
           '/workspace',
           'node:24-alpine',


### PR DESCRIPTION
Add SELinux mount option `Z` to the workspace volume mount in the shell command, ensuring the workspace directory is accessible within the container on SELinux-enabled systems.

## Changes

- Updated Docker volume mount in `shellCommand` to include the `Z` SELinux label option (`/workspace:Z,rw`)

## Notes

This change specifically addresses SELinux-enforcing systems (like Fedora, RHEL, CentOS) where Docker containers need explicit SELinux context labels to access host directories. The `Z` option tells Docker to automatically label the volume with a private unshared label, allowing the container to access the workspace files.