### PR TITLE
chore: migrate IterationStatus to rover-schemas package

### DIFF
--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -1,9 +1,8 @@
 import { CommandOutput } from '../cli.js';
 import colors from 'ansi-colors';
-import { WorkflowManager } from 'rover-schemas';
+import { WorkflowManager, IterationStatusManager } from 'rover-schemas';
 import { parseCollectOptions } from '../lib/options.js';
 import { Runner } from '../lib/runner.js';
-import { IterationStatus } from 'rover-common';
 import { existsSync, readFileSync } from 'node:fs';
 
 interface RunCommandOptions {
@@ -38,7 +37,7 @@ export const runCommand = async (
   };
 
   // Declare status manager outside try block so it's accessible in catch
-  let statusManager: IterationStatus | undefined;
+  let statusManager: IterationStatusManager | undefined;
   let totalDuration = 0;
 
   try {
@@ -63,7 +62,7 @@ export const runCommand = async (
     // Create status manager if status file is provided
     if (options.statusFile && options.taskId) {
       try {
-        statusManager = IterationStatus.createInitial(
+        statusManager = IterationStatusManager.createInitial(
           options.statusFile,
           options.taskId,
           'Starting workflow'

--- a/packages/agent/src/lib/runner.ts
+++ b/packages/agent/src/lib/runner.ts
@@ -4,7 +4,7 @@
  * by building the prompt and passing it.
  */
 
-import { launch, launchSync, VERBOSE, IterationStatus } from 'rover-common';
+import { launch, launchSync, VERBOSE } from 'rover-common';
 import colors from 'ansi-colors';
 import {
   copyFileSync,
@@ -14,7 +14,7 @@ import {
   rmSync,
 } from 'node:fs';
 import type { WorkflowAgentStep, WorkflowOutputType } from 'rover-schemas';
-import { WorkflowManager } from 'rover-schemas';
+import { WorkflowManager, IterationStatusManager } from 'rover-schemas';
 import {
   parseAgentError,
   isWaitingForAuthentication,
@@ -55,7 +55,7 @@ export class Runner {
     private stepsOutput: Map<string, Map<string, string>>,
     private defaultTool: string | undefined,
     private defaultModel: string | undefined,
-    private statusManager?: IterationStatus,
+    private statusManager?: IterationStatusManager,
     private totalSteps: number = 0,
     private currentStepIndex: number = 0
   ) {

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -3,7 +3,8 @@ import { formatTaskStatus, statusColor } from '../utils/task-status.js';
 import { showTips } from '../utils/display.js';
 import { getTelemetry } from '../lib/telemetry.js';
 import { getDescriptions, TaskDescriptionSchema } from '../lib/description.js';
-import { VERBOSE, type IterationStatusSchema } from 'rover-common';
+import { VERBOSE } from 'rover-common';
+import { IterationStatusManager } from 'rover-schemas';
 import {
   getLastTaskIteration,
   getTaskIterations,
@@ -190,7 +191,7 @@ export const listCommand = async (
 
       const maybeIterationStatus: (
         iteration?: IterationConfig
-      ) => IterationStatusSchema | undefined = iteration => {
+      ) => IterationStatusManager | undefined = iteration => {
         try {
           return iteration?.status();
         } catch (e) {

--- a/packages/cli/src/lib/iteration.ts
+++ b/packages/cli/src/lib/iteration.ts
@@ -6,7 +6,8 @@ import colors from 'ansi-colors';
 import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { TaskDescription } from './description.js';
-import { VERBOSE, type IterationStatusSchema } from 'rover-common';
+import { VERBOSE } from 'rover-common';
+import { IterationStatusManager } from 'rover-schemas';
 
 const CURRENT_ITERATION_SCHEMA_VERSION = '1.0';
 export const ITERATION_FILENAME = 'iteration.json';
@@ -45,7 +46,7 @@ export class IterationConfig {
   private data: IterationConfigSchema;
   private filePath: string;
   private iterationPath: string;
-  private statusCache: IterationStatusSchema | undefined;
+  private statusCache: IterationStatusManager | undefined;
 
   constructor(
     data: IterationConfigSchema,
@@ -175,15 +176,14 @@ export class IterationConfig {
   /**
    * Load the iteration status
    */
-  status(): IterationStatusSchema {
+  status(): IterationStatusManager {
     if (this.statusCache) return this.statusCache;
 
     const statusPath = join(this.iterationPath, ITERATION_STATUS_FILENAME);
 
     if (existsSync(statusPath)) {
       try {
-        const content = readFileSync(statusPath, 'utf8');
-        const status = JSON.parse(content) as IterationStatusSchema;
+        const status = IterationStatusManager.load(statusPath);
         this.statusCache = status;
 
         return status;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -19,8 +19,6 @@ export { getVersion } from './version.js';
 
 export { Git } from './git.js';
 
-export { IterationStatus, type IterationStatusSchema } from './status.js';
-
 export {
   requiredClaudeCredentials,
   requiredBedrockCredentials,

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -22,3 +22,16 @@ export {
 } from './workflow/errors.js';
 
 export { WorkflowManager } from './workflow.js';
+
+// Iteration Status library
+export {
+  type IterationStatus,
+  type IterationStatusName,
+} from './iteration-status/types.js';
+
+export {
+  IterationStatusLoadError,
+  IterationStatusValidationError,
+} from './iteration-status/errors.js';
+
+export { IterationStatusManager } from './iteration-status.js';

--- a/packages/schemas/src/iteration-status/errors.ts
+++ b/packages/schemas/src/iteration-status/errors.ts
@@ -1,0 +1,27 @@
+import { ZodError } from 'zod';
+
+/**
+ * Error class for iteration status loading errors
+ */
+export class IterationStatusLoadError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'IterationStatusLoadError';
+  }
+}
+
+/**
+ * Error class for iteration status validation errors
+ */
+export class IterationStatusValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly validationErrors: ZodError
+  ) {
+    super(message);
+    this.name = 'IterationStatusValidationError';
+  }
+}

--- a/packages/schemas/src/iteration-status/schema.ts
+++ b/packages/schemas/src/iteration-status/schema.ts
@@ -1,0 +1,39 @@
+/**
+ * Zod schemas for runtime validation of iteration status tracking
+ */
+
+import { z } from 'zod';
+
+/**
+ * Supported status names
+ */
+export const IterationStatusNameSchema = z.enum([
+  'initializing',
+  'running',
+  'completed',
+  'failed',
+]);
+
+/**
+ * Schema for iteration status tracking
+ * Represents the state of an iteration during workflow execution
+ */
+export const IterationStatusSchema = z.object({
+  /** Original Task ID */
+  taskId: z.string(),
+
+  /** Status name (e.g., 'initializing', 'running', 'completed', 'failed') */
+  status: IterationStatusNameSchema,
+
+  /** Current step name and progress */
+  currentStep: z.string(),
+  progress: z.number(),
+
+  /** Timestamps in ISO 8601 format */
+  startedAt: z.string(),
+  updatedAt: z.string(),
+  completedAt: z.string().optional(),
+
+  /** Error information */
+  error: z.string().optional(),
+});

--- a/packages/schemas/src/iteration-status/types.ts
+++ b/packages/schemas/src/iteration-status/types.ts
@@ -1,0 +1,19 @@
+/**
+ * TypeScript types for iteration status tracking
+ * All types are inferred from Zod schemas to ensure consistency
+ */
+
+import { z } from 'zod';
+import { IterationStatusSchema, IterationStatusNameSchema } from './schema.js';
+
+/**
+ * Type representing a specific status name for the current iteration
+ * Inferred from IterationStatusNameSchema to ensure type safety
+ */
+export type IterationStatusName = z.infer<typeof IterationStatusNameSchema>;
+
+/**
+ * Type representing the iteration status data structure
+ * Inferred from IterationStatusSchema to ensure type safety
+ */
+export type IterationStatus = z.infer<typeof IterationStatusSchema>;

--- a/packages/schemas/src/workflow/schema.ts
+++ b/packages/schemas/src/workflow/schema.ts
@@ -180,13 +180,14 @@ export const WorkflowSequentialStepSchema: z.ZodType<any> =
  * Union of all step types (discriminated by 'type' field)
  * Forward declared for recursive types
  */
-export const WorkflowStepSchema: z.ZodType<any> = z.union([
-  WorkflowAgentStepSchema,
-  // CommandStepSchema,
-  // ConditionalStepSchema,
-  // ParallelStepSchema,
-  // SequentialStepSchema,
-]);
+export const WorkflowStepSchema: z.ZodType<any> = WorkflowAgentStepSchema;
+// export const WorkflowStepSchema: z.ZodType<any> = z.union([
+//   WorkflowAgentStepSchema,
+//   // CommandStepSchema,
+//   // ConditionalStepSchema,
+//   // ParallelStepSchema,
+//   // SequentialStepSchema,
+// ]);
 
 /**
  * Complete agent workflow schema


### PR DESCRIPTION
Migrate the iteration status management from the common package to the rover-schemas package, following the established architectural pattern. This centralizes all project file schemas and provides improved type safety through Zod validation.

## Changes

- Created new Zod schema for iteration status validation in `packages/schemas/src/iteration-status/schema.ts`
- Added TypeScript types inferred from Zod schemas in `packages/schemas/src/iteration-status/types.ts`
- Implemented custom error classes (LoadError, ValidationError) in `packages/schemas/src/iteration-status/errors.ts`
- Refactored IterationStatus class into IterationStatusManager following the WorkflowManager pattern
- Updated all imports in agent, cli, and common packages to use the new schemas package
- Migrated and adapted existing tests to the schemas package

## Notes

The migration maintains full backward compatibility with existing functionality while introducing runtime validation through Zod schemas. The new structure follows the pattern established in `docs/schemas.md` for consistent schema management across the project.

Closes #246