### PR TITLE
feat: add --raw-file option to rover inspect command

### DIFF
--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -259,6 +259,10 @@ export function createProgram(
       'Specific iteration number (defaults to latest)'
     )
     .option('--file <files...>', 'Output iteration file contents')
+    .option(
+      '--raw-file <files...>',
+      'Output raw file contents without formatting (mutually exclusive with --file)'
+    )
     .option('--json', 'Output in JSON format')
     .action(inspectCommand);
 


### PR DESCRIPTION
Adds a new `--raw-file` option to the `rover inspect` command that outputs file content without decorative formatting. This enables piping file content directly to other tools or saving it for automation purposes.

The option is mutually exclusive with `--file` to prevent confusion. When used with `--json`, it returns structured output with the `RawFileOutput` interface.

## Changes

- Added `RawFileOutput` interface for JSON output format with `success`, `files[]`, and `error` properties
- Added `--raw-file <files...>` option to the inspect command, mutually exclusive with `--file`
- Implemented raw file output in both text and JSON modes
- Added validation to prevent using `--file` and `--raw-file` together
- Text mode outputs plain file content without borders or formatting
- JSON mode returns structured output with file metadata and content

## Notes

The `RawFileOutput` interface supports multiple files in a single request:

```json
{
  "success": true,
  "files": [
    {
      "filename": "summary.md",
      "content": "# Task Summary\n..."
    }
  ]
}
```

When a requested file is not found, the response includes an empty content string and sets `success: false` with an error message.

Closes #268