### PR TITLE
fix: remove deprecated -p flag from Gemini CLI invocation

### DIFF
--- a/packages/cli/src/lib/agents/gemini.ts
+++ b/packages/cli/src/lib/agents/gemini.ts
@@ -42,7 +42,8 @@ class GeminiAI implements AIAgentTool {
   }
 
   async invoke(prompt: string, json: boolean = false): Promise<string> {
-    const geminiArgs = ['-p'];
+    // Do not add -p, it's deprecated
+    const geminiArgs: string[] = [];
 
     if (json) {
       // Gemini does not have any way to force the JSON output at CLI level.


### PR DESCRIPTION
Fixes the Gemini agent task expansion failure by removing the deprecated `-p` flag from the Gemini CLI invocation. The latest Gemini CLI version no longer supports this option, causing task expansion to fail.

The fix aligns the CLI's Gemini agent implementation with the approach already used in the `packages/agent` package, which passes prompts via stdin instead of using the `-p` flag.

## Changes

- Removed deprecated `-p` flag from Gemini CLI argument array in `packages/cli/src/lib/agents/gemini.ts`
- Added comment explaining why the flag was removed
- Gemini prompts are now passed exclusively via stdin (existing behavior)

## Notes

The `packages/agent` package was already using the correct approach by not using the `-p` flag. This change brings the CLI package in line with that implementation.

Closes #274