### PR TITLE
fix: show progress correctly after introducing the table display helper

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -226,7 +226,9 @@ export const listCommand = async (
       },
       {
         header: 'Progress',
-        key: (row: TaskRow) => formatProgress(row.status, row.progress),
+        key: 'progress',
+        format: (_value: string, row: TaskRow) =>
+          formatProgress(row.status, row.progress),
         width: 10,
       },
       {


### PR DESCRIPTION
Fix a regression introduced in #269 . The `rover list` command was not showing progress correctly.

## Demo

```
$ rover list
Rover (v1.4.1) · /home/angel/Workspace/yaml
-------------------------------------------
ID Title                          Agent    Workflow Status       Progress   Current Step    Duration
──────────────────────────────────────────────────────────────────────────────────────────────────────
2  Fix extra blank line in YAM... claude   swe      Iterating    ███░░░░░   Implementation  2m 39s
1  Fix YAML stringify extra bl... codex    swe      Iterating    ███░░░░░   Implementation  3m 2s

Tip: Use rover task to assign a new task to an agent
Tip: Use rover inspect <id> to see the task details
```