### PR TITLE
feat(extension): load workflows using the Rover CLI

### DIFF
--- a/packages/extension/src/providers/TasksLitWebviewProvider.mts
+++ b/packages/extension/src/providers/TasksLitWebviewProvider.mts
@@ -37,7 +37,8 @@ export class TasksLitWebviewProvider implements vscode.WebviewViewProvider {
             data.description,
             data.agent,
             data.branch,
-            data.workflow
+            data.workflow,
+            data.workflowInputs
           );
           break;
         case 'refreshTasks':
@@ -99,7 +100,8 @@ export class TasksLitWebviewProvider implements vscode.WebviewViewProvider {
     description: string,
     agent?: string,
     branch?: string,
-    workflow?: string
+    workflow?: string,
+    workflowInputs?: Record<string, any>
   ) {
     try {
       // Show progress bar while creating task
@@ -115,7 +117,8 @@ export class TasksLitWebviewProvider implements vscode.WebviewViewProvider {
             description.trim(),
             agent,
             branch,
-            workflow
+            workflow,
+            workflowInputs
           );
 
           // Send success message back to webview


### PR DESCRIPTION
Enhances the VS Code extension to dynamically load workflows from the Rover CLI instead of using a hardcoded list. This enables users to leverage custom workflows defined in their Rover configuration, including workflows with custom input fields.

Closes #291

## Changes

- Added `getWorkflows()` method to `RoverCLI` class that calls `rover workflows list --json` to fetch available workflows
- Updated `getSettings()` to call `getWorkflows()` and return the dynamic list instead of hardcoded workflows
- Extended workflow interface to include optional `inputs` array for workflow-specific parameters
- Updated `createTask()` method to accept and pass `workflowInputs` via stdin as JSON
- Enhanced `CreateForm` component to render custom input fields based on workflow inputs
- Added input validation and type handling for string, number, and boolean workflow inputs
- Implemented `initializeWorkflowInputs()` to set default values for workflow parameters
- Added input value persistence when workflow list updates but selected workflow remains valid
- Filtered out the `description` input field from custom inputs as it's handled separately

## Notes

The extension now supports workflows with custom inputs, enabling more flexible task creation. Input values are validated client-side and passed to the CLI via stdin in JSON format, matching the CLI's expected workflow input mechanism.