### PR TITLE
chore: refer to the latest iteration if there is more than one available

### DIFF
--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -438,7 +438,10 @@ export const iterateCommand = async (
 
     // Start sandbox container for task execution
     const sandbox = await createSandbox(task);
-    await sandbox.createAndStart();
+    const containerId = await sandbox.createAndStart();
+
+    // Update task metadata with new container ID for this iteration
+    task.setContainerInfo(containerId, 'running');
 
     result.success = true;
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -165,7 +165,10 @@ export const restartCommand = async (
     // Start sandbox container for task execution
     try {
       const sandbox = await createSandbox(task);
-      await sandbox.createAndStart();
+      const containerId = await sandbox.createAndStart();
+
+      // Update task metadata with new container ID
+      task.setContainerInfo(containerId, 'running');
     } catch (error) {
       // If sandbox execution fails, reset task back to NEW status
       task.resetToNew();


### PR DESCRIPTION
Fixes an issue where the container ID was not being updated in task metadata after creating a new sandbox container in iterate and restart commands. This caused the task to reference stale container information from previous iterations.

Fixes: #292

## Changes

- Modified `iterate` command to capture and store the container ID returned from `sandbox.createAndStart()`
- Modified `restart` command to capture and store the container ID returned from `sandbox.createAndStart()`
- Added `task.setContainerInfo()` calls to update task metadata with the new container ID and 'running' status

## Notes

This ensures that subsequent operations on the task (such as checking status or stopping the container) reference the correct, current container ID rather than an outdated one from a previous iteration.