### PR TITLE
chore: automate publish workflow trigger from release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       project:
-        description: 'Select the project to release'
+        description: 'Select the project to publish'
         required: true
         type: choice
         default: cli
@@ -15,13 +15,34 @@ on:
           - cli
           - extension
       version:
-        description: 'The project version to release'
+        description: 'The project version to publish (e.g. 1.0.0)'
         required: true
       dryRun:
         description: 'Dry-run job to avoid publishing to NPM or the extension marketplaces'
         required: true
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      project:
+        description: 'Select the project to publish'
+        required: true
+        type: string
+      version:
+        description: 'The project version to publish (e.g. 1.0.0)'
+        required: true
+        type: string
+      dryRun:
+        description: 'Dry-run job to avoid publishing to NPM or the extension marketplaces'
+        required: true
+        type: boolean
+    secrets:
+      NPM_TOKEN:
+        required: true
+      VSCODE_MARKETPLACE_TOKEN:
+        required: true
+      GOOGLE_CHAT_WEBHOOK:
+        required: true
 
 env:
   TAG_NAME: ${{ inputs.project }}/v${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
           - cli
           - extension
       targetVersion:
-        description: 'Version to publish (e.g. 1.0.0)'
+        description: 'Version to release (e.g. 1.0.0)'
         type: string
         required: true
       publishRelease:
@@ -38,6 +38,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    secrets: inherit
 
   release:
     needs: build-image
@@ -196,19 +197,15 @@ jobs:
           }
           EOF
 
-      - name: Trigger Publish Workflow
-        if: success() && inputs.publishRelease == true && inputs.dryRun == false
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          echo "⚠️  Manual action required: Please run the publish workflow manually"
-          echo "Navigate to Actions > Publish workflow and run with:"
-          echo "  - Project: ${{ inputs.project }}"
-          echo "  - Version: ${{ inputs.targetVersion }}"
-          echo "  - Dry Run: ${{ inputs.dryRun }}"
-          # gh workflow run publish.yml \
-          #   --repo ${{ github.repository }} \
-          #   --ref ${{ github.ref }} \
-          #   -f project=${{ inputs.project }} \
-          #   -f version=${{ inputs.targetVersion }} \
-          #   -f dryRun=${{ inputs.dryRun }}
+  publish:
+    needs: release
+    if: always() && needs.release.result == 'success' && inputs.publishRelease == true && inputs.dryRun == false
+    uses: ./.github/workflows/publish.yml
+    with:
+      project: ${{ inputs.project }}
+      version: ${{ inputs.targetVersion }}
+      dryRun: false
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCODE_MARKETPLACE_TOKEN }}
+      GOOGLE_CHAT_WEBHOOK: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}


### PR DESCRIPTION
Automates the publish workflow by converting it to a reusable workflow that can be called directly from the release workflow, eliminating the need for manual intervention.

Previously, after a successful release, developers had to manually trigger the publish workflow through the GitHub Actions UI. This change streamlines the release process by automatically triggering the publish workflow when a release completes successfully.

## Changes

- Converted the publish workflow to support both `workflow_dispatch` and `workflow_call` triggers
- Added workflow call inputs and secrets configuration to enable reusability
- Updated the release workflow to call the publish workflow automatically when `publishRelease` is true and `dryRun` is false
- Removed the manual trigger reminder in favor of automated workflow execution
- Updated input descriptions for clarity (distinguishing between "release" and "publish")

## Notes

The publish workflow now supports two execution modes:
1. Manual dispatch through the GitHub Actions UI (unchanged)
2. Automatic invocation from the release workflow (new)

The automatic trigger only occurs when both conditions are met:
- `publishRelease` is set to `true`
- `dryRun` is set to `false`

This ensures that dry-run releases don't accidentally publish packages.