### PR TITLE
chore: fix gemini installation in agent container

### DIFF
--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -2,6 +2,7 @@ ARG NIX_AI_TOOLS_REV=ea213e13fde802090a4cdec57631e3374d67d78f
 FROM node:24-alpine AS agent-builder
 COPY . /app
 WORKDIR /app
+
 # Build the agent
 RUN npm install && npm run build:agent
 RUN cd ./packages/agent && npm pack && mv *.tgz /rover-agent.tgz
@@ -12,7 +13,7 @@ ARG TARGETARCH
 ARG PACKAGE_MANAGER_MCP_SERVER_VERSION="v0.2.0"
 ENV NIX_AI_TOOLS_REV=${NIX_AI_TOOLS_REV}
 RUN apk update && \
-    apk add bash file jq nix python3 sudo uv && \
+    apk add bash file g++ jq make nix python3 sudo uv && \
     case ${TARGETARCH} in \
       amd64) ARCH_SUFFIX="x86_64-unknown-linux-musl" ;; \
       arm64) ARCH_SUFFIX="aarch64-unknown-linux-musl" ;; \


### PR DESCRIPTION
Fix the Gemini AI provider installation in the agent Docker container by adding required build dependencies.

The Gemini AI provider requires native compilation during installation, which needs `g++` and `make` to build native modules. Without these dependencies, the installation fails during the Docker build process.

## Changes

- Added `g++` and `make` to the agent container's Alpine package dependencies
- Minor formatting cleanup (blank line in Dockerfile)

Closes: #321