### PR TITLE
chore: forward verbose option to the rover agent

### DIFF
--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -4,7 +4,7 @@ import { ProjectConfigManager } from 'rover-schemas';
 import { Sandbox } from './types.js';
 import { SetupBuilder } from '../setup.js';
 import { TaskDescriptionManager } from 'rover-schemas';
-import { findProjectRoot, launch, ProcessManager } from 'rover-common';
+import { findProjectRoot, launch, ProcessManager, VERBOSE } from 'rover-common';
 import {
   parseCustomEnvironmentVariables,
   loadEnvsFile,
@@ -237,6 +237,11 @@ export class DockerSandbox extends Sandbox {
       '--inputs-json',
       '/inputs.json'
     );
+
+    // Forward verbose flag to rover-agent if enabled
+    if (VERBOSE) {
+      dockerArgs.push('-v');
+    }
 
     // Add pre-context file arguments
     preContextPaths.forEach((_, index) => {

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -9,6 +9,7 @@ import {
   findProjectRoot,
   launch,
   ProcessManager,
+  VERBOSE,
 } from 'rover-common';
 import {
   parseCustomEnvironmentVariables,
@@ -212,6 +213,11 @@ export class PodmanSandbox extends Sandbox {
       '--inputs-json',
       '/inputs.json'
     );
+
+    // Forward verbose flag to rover-agent if enabled
+    if (VERBOSE) {
+      podmanArgs.push('-v');
+    }
 
     // Add pre-context file arguments
     preContextPaths.forEach((_, index) => {


### PR DESCRIPTION
Forward the verbose flag from the CLI to the rover-agent running inside Docker/Podman containers. This ensures that when users run rover commands with the verbose flag, the agent also operates in verbose mode for better debugging visibility.

## Changes

- Import `VERBOSE` flag from `rover-common` in both Docker and Podman sandbox implementations
- Add verbose flag (`-v`) to the rover-agent arguments when `VERBOSE` is enabled
- Applied consistently across both `DockerSandbox` and `PodmanSandbox` classes

Closes: #319