### PR TITLE
chore: do not run build-dev-image on PR's rather than skip

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -1,0 +1,15 @@
+name: Build Dev Image
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-dev-image:
+    uses: ./.github/workflows/build-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      tag: latest
+      image-name: ghcr.io/${{ github.repository }}/agent-dev

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -45,14 +45,3 @@ jobs:
       - name: Test Build Artifact
         run: node dist/index.js --version
         working-directory: packages/cli
-
-  build-dev-image:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
-    uses: ./.github/workflows/build-image.yml
-    permissions:
-      contents: read
-      packages: write
-    with:
-      tag: latest
-      image-name: ghcr.io/${{ github.repository }}/agent-dev


### PR DESCRIPTION
This does not show a 'skipped check' in GitHub for every PR. The trigger of the `build-dev-image` workflow will only happen on pushes to the `main` branch.

This fixes the following on every PR:

<img width="858" height="499" alt="Screenshot 2025-11-28 at 09 22 21" src="https://github.com/user-attachments/assets/935c8416-6809-40e8-b1b5-95615a0c8a28" />
