### PR TITLE
feat: support HTTP URLs and file paths in workflow inspect command

### DIFF
--- a/packages/cli/src/commands/workflows/__tests__/inspect.test.ts
+++ b/packages/cli/src/commands/workflows/__tests__/inspect.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { inspectWorkflowCommand } from '../inspect.js';
+
+// Mock telemetry to avoid external calls
+vi.mock('../../../lib/telemetry.js', () => ({
+  getTelemetry: vi.fn().mockReturnValue({
+    eventInspectWorkflow: vi.fn(),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+// Mock workflow store
+vi.mock('../../../lib/workflow.js', () => ({
+  initWorkflowStore: vi.fn().mockReturnValue({
+    getWorkflow: vi.fn((name: string) => {
+      if (name === 'swe') {
+        return {
+          name: 'swe',
+          description: 'Software engineering workflow',
+          version: '1.0.0',
+          inputs: [
+            {
+              name: 'task',
+              description: 'Task to complete',
+              required: true,
+            },
+          ],
+          outputs: [
+            {
+              name: 'result',
+              description: 'Task result',
+            },
+          ],
+          steps: [
+            {
+              name: 'analyze',
+              outputs: [{ name: 'analysis' }],
+            },
+            {
+              name: 'implement',
+              outputs: [{ name: 'code' }],
+            },
+          ],
+          defaults: {
+            tool: 'claude',
+            model: 'claude-3-sonnet',
+          },
+          config: {
+            timeout: 300,
+            continueOnError: false,
+          },
+          filePath: '/builtin/swe.yml',
+          toObject: vi.fn().mockReturnValue({
+            name: 'swe',
+            description: 'Software engineering workflow',
+            version: '1.0.0',
+          }),
+        };
+      }
+      return undefined;
+    }),
+  }),
+}));
+
+// Mock global fetch for HTTP tests
+global.fetch = vi.fn();
+
+describe('inspect workflow command', () => {
+  let testDir: string;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Create temp directory for testing
+    testDir = mkdtempSync(join(tmpdir(), 'rover-inspect-test-'));
+
+    // Spy on console methods
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Clean up temp directory
+    rmSync(testDir, { recursive: true, force: true });
+
+    // Clear all mocks
+    vi.clearAllMocks();
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('workflow name lookup', () => {
+    it('should load built-in workflow by name', async () => {
+      await inspectWorkflowCommand('swe', { json: false, raw: false });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Workflow Details');
+      expect(output).toContain('swe');
+      expect(output).toContain('Software engineering workflow');
+    });
+
+    it('should handle non-existent workflow name', async () => {
+      await inspectWorkflowCommand('nonexistent', { json: false, raw: false });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Workflow "nonexistent" not found');
+    });
+
+    it('should output JSON for workflow name with --json flag', async () => {
+      await inspectWorkflowCommand('swe', { json: true, raw: false });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls[0]?.[0];
+      if (typeof output !== 'string') {
+        throw new Error('Expected console.log output to be a string');
+      }
+      const parsed = JSON.parse(output);
+      expect(parsed.success).toBe(true);
+      expect(parsed.workflow.name).toBe('swe');
+      expect(parsed.source).toBe('built-in');
+    });
+  });
+
+  describe('local file loading', () => {
+    it('should load workflow from local file path', async () => {
+      const workflowFile = join(testDir, 'test-workflow.yml');
+      const workflowContent = `name: test-workflow
+description: Test workflow
+version: 1.0.0
+inputs:
+  - name: input1
+    description: Test input
+    type: string
+    required: true
+outputs:
+  - name: output1
+    description: Test output
+    type: string
+steps:
+  - id: step1
+    name: step1
+    type: agent
+    prompt: Test step
+`;
+      writeFileSync(workflowFile, workflowContent);
+
+      await inspectWorkflowCommand(workflowFile, { json: false, raw: false });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Workflow Details');
+      expect(output).toContain('test-workflow');
+    });
+
+    it('should handle missing file path', async () => {
+      const missingFile = join(testDir, 'missing.yml');
+
+      await inspectWorkflowCommand(missingFile, { json: false, raw: false });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain(`File not found: ${missingFile}`);
+    });
+
+    it('should output raw YAML with --raw flag', async () => {
+      const workflowFile = join(testDir, 'test-workflow.yml');
+      const workflowContent = `name: test-workflow
+description: Test workflow
+version: 1.0.0
+steps:
+  - id: step1
+    name: step1
+    type: agent
+    prompt: Test step
+`;
+      writeFileSync(workflowFile, workflowContent);
+
+      await inspectWorkflowCommand(workflowFile, { json: false, raw: true });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls[0]?.[0];
+      if (typeof output !== 'string') {
+        throw new Error('Expected console.log output to be a string');
+      }
+      expect(output).toContain('name: test-workflow');
+      expect(output).toContain('description: Test workflow');
+    });
+  });
+
+  describe('HTTP URL fetching', () => {
+    beforeEach(() => {
+      // Reset fetch mock before each test
+      (global.fetch as ReturnType<typeof vi.fn>).mockReset();
+    });
+
+    it('should fetch and load workflow from HTTP URL', async () => {
+      const workflowContent = `name: remote-workflow
+description: Remote workflow
+version: 1.0.0
+steps:
+  - id: step1
+    name: step1
+    type: agent
+    prompt: Remote step
+`;
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-length': '100' }),
+        text: async () => workflowContent,
+      });
+
+      await inspectWorkflowCommand('https://example.com/workflow.yml', {
+        json: false,
+        raw: false,
+      });
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://example.com/workflow.yml',
+        expect.objectContaining({
+          signal: expect.any(AbortSignal),
+        })
+      );
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Workflow Details');
+      expect(output).toContain('remote-workflow');
+    });
+
+    it('should handle network errors when fetching from URL', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Network error')
+      );
+
+      await inspectWorkflowCommand('https://example.com/workflow.yml', {
+        json: false,
+        raw: false,
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Failed to fetch workflow from URL');
+      expect(output).toContain('Network error');
+    });
+
+    it('should handle HTTP error responses', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await inspectWorkflowCommand('https://example.com/workflow.yml', {
+        json: false,
+        raw: false,
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('HTTP 404: Not Found');
+    });
+
+    it('should reject files that are too large', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({
+          'content-length': (11 * 1024 * 1024).toString(),
+        }), // 11MB
+      });
+
+      await inspectWorkflowCommand('https://example.com/workflow.yml', {
+        json: false,
+        raw: false,
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Workflow file too large');
+    });
+
+    it('should handle timeout errors', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        return new Promise((_, reject) => {
+          const error = new Error('Aborted');
+          error.name = 'AbortError';
+          setTimeout(() => reject(error), 100);
+        });
+      });
+
+      await inspectWorkflowCommand('https://example.com/workflow.yml', {
+        json: false,
+        raw: false,
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Request timeout');
+    });
+
+    it('should reject invalid URL formats', async () => {
+      await inspectWorkflowCommand('not-a-valid-url', {
+        json: false,
+        raw: false,
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Workflow "not-a-valid-url" not found');
+    });
+
+    it('should handle empty response from URL', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-length': '0' }),
+        text: async () => '',
+      });
+
+      await inspectWorkflowCommand('https://example.com/workflow.yml', {
+        json: false,
+        raw: false,
+      });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      const output = consoleLogSpy.mock.calls
+        .map(call => call.join(' '))
+        .join('\n');
+      expect(output).toContain('Empty response from URL');
+    });
+  });
+
+  describe('source type detection', () => {
+    it('should detect HTTP URLs correctly', async () => {
+      const workflowContent = `name: http-workflow
+description: HTTP workflow
+version: 1.0.0
+steps:
+  - id: step1
+    name: step1
+    type: agent
+    prompt: Test
+`;
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-length': '100' }),
+        text: async () => workflowContent,
+      });
+
+      await inspectWorkflowCommand('http://example.com/workflow.yml', {
+        json: true,
+        raw: false,
+      });
+
+      const output = consoleLogSpy.mock.calls[0]?.[0];
+      if (typeof output !== 'string') {
+        throw new Error('Expected console.log output to be a string');
+      }
+      const parsed = JSON.parse(output);
+      expect(parsed.source).toBe('http://example.com/workflow.yml');
+    });
+
+    it('should detect file paths with slashes', async () => {
+      const workflowFile = join(testDir, 'test.yml');
+      const workflowContent = `name: file-workflow
+description: File workflow
+version: 1.0.0
+steps:
+  - id: step1
+    name: step1
+    type: agent
+    prompt: Test
+`;
+      writeFileSync(workflowFile, workflowContent);
+
+      await inspectWorkflowCommand(workflowFile, { json: true, raw: false });
+
+      const output = consoleLogSpy.mock.calls[0]?.[0];
+      if (typeof output !== 'string') {
+        throw new Error('Expected console.log output to be a string');
+      }
+      const parsed = JSON.parse(output);
+      expect(parsed.source).toBe(workflowFile);
+    });
+
+    it('should detect file paths with .yml extension', async () => {
+      const workflowFile = join(testDir, 'workflow.yml');
+      const workflowContent = `name: yml-workflow
+description: YML workflow
+version: 1.0.0
+steps:
+  - id: step1
+    name: step1
+    type: agent
+    prompt: Test
+`;
+      writeFileSync(workflowFile, workflowContent);
+
+      await inspectWorkflowCommand(workflowFile, { json: true, raw: false });
+
+      const output = consoleLogSpy.mock.calls[0]?.[0];
+      if (typeof output !== 'string') {
+        throw new Error('Expected console.log output to be a string');
+      }
+      const parsed = JSON.parse(output);
+      expect(parsed.source).toBe(workflowFile);
+    });
+  });
+});

--- a/packages/cli/src/commands/workflows/index.ts
+++ b/packages/cli/src/commands/workflows/index.ts
@@ -19,8 +19,10 @@ export const addWorkflowCommands = (program: Command) => {
     .action(listWorkflowsCommand);
 
   command
-    .command('inspect <workflow-name>')
-    .description('Display detailed information about a specific workflow')
+    .command('inspect <workflow-source>')
+    .description(
+      'Display detailed information about a specific workflow (name, URL, or file path)'
+    )
     .option('--json', 'Output workflow details in JSON format', false)
     .option('--raw', 'Output workflow as raw YAML', false)
     .action(inspectWorkflowCommand);


### PR DESCRIPTION
This enhancement extends the `rover workflows inspect` command to support loading workflows from multiple sources, making it more flexible and useful for inspecting custom and remote workflows.

Closes: #344

## Changes

- Enhanced `inspect` command to accept workflow names, HTTP/HTTPS URLs, or file paths
- Added automatic source type detection based on input format
- Implemented `fetchWorkflowFromUrl()` function with security features:
  - 10-second request timeout
  - 10MB file size limit
  - URL validation (HTTP/HTTPS only)
- Added temporary file management for fetched workflows
- Enhanced error handling with detailed messages for network failures, timeouts, and invalid sources
- Updated command description to reflect new capabilities
- Added comprehensive test suite covering all source types and edge cases
- Improved JSON output to include source information

## Notes

The HTTP fetching implementation includes several security measures to prevent abuse:
- Timeout protection (10s) to avoid hanging requests
- File size limits (10MB) to prevent memory exhaustion
- URL protocol validation to ensure only HTTP/HTTPS
- Proper cleanup of temporary files after inspection

The workflow inspect command now supports three modes:
1. **Built-in workflows**: `rover workflows inspect swe`
2. **Local files**: `rover workflows inspect ./custom-workflow.yml`
3. **Remote URLs**: `rover workflows inspect https://example.com/workflow.yml`