### PR TITLE
fix: use undefined instead of empty strings for optional datetime fields in migration

### DIFF
--- a/packages/schemas/src/task-description.ts
+++ b/packages/schemas/src/task-description.ts
@@ -184,23 +184,23 @@ export class TaskDescriptionManager {
     // Preserve all execution-related fields
     migrated.containerId = data.containerId || '';
     migrated.executionStatus = data.executionStatus || '';
-    migrated.runningAt = data.runningAt || '';
-    migrated.errorAt = data.errorAt || '';
+    migrated.runningAt = data.runningAt || undefined;
+    migrated.errorAt = data.errorAt || undefined;
     migrated.exitCode = data.exitCode || 0;
 
     // Preserve optional datetime fields
-    migrated.startedAt = data.startedAt || '';
-    migrated.completedAt = data.completedAt || '';
-    migrated.failedAt = data.failedAt || '';
-    migrated.lastIterationAt = data.lastIterationAt || '';
-    migrated.lastStatusCheck = data.lastStatusCheck || '';
+    migrated.startedAt = data.startedAt || undefined;
+    migrated.completedAt = data.completedAt || undefined;
+    migrated.failedAt = data.failedAt || undefined;
+    migrated.lastIterationAt = data.lastIterationAt || undefined;
+    migrated.lastStatusCheck = data.lastStatusCheck || undefined;
 
     // Preserve error information
     migrated.error = data.error;
 
     // Preserve restart tracking information
     migrated.restartCount = data.restartCount || 0;
-    migrated.lastRestartAt = data.lastRestartAt || '';
+    migrated.lastRestartAt = data.lastRestartAt || undefined;
 
     // Preserve agent and sourceBranch fields
     migrated.agent = data.agent;


### PR DESCRIPTION
Fixes the task migration logic to use `undefined` instead of empty strings for optional datetime fields. When migrating tasks from v1.1 schema, fields like `startedAt`, `completedAt`, `failedAt`, and others were being set to empty strings, which could cause validation issues or incorrect behavior when checking for the presence of these values.

Fixes: https://github.com/endorhq/rover/issues/375

## Changes

- Updated `migrateToLatest()` in `TaskDescriptionManager` to use `undefined` as the fallback value for optional datetime fields instead of empty strings
- Added test case to verify that migrated tasks have `undefined` for missing datetime fields

## Notes

The affected fields are: `runningAt`, `errorAt`, `startedAt`, `completedAt`, `failedAt`, `lastIterationAt`, `lastStatusCheck`, and `lastRestartAt`.