### PR TITLE
fix: prevent -a option from consuming task description

### DIFF
--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -212,8 +212,10 @@ export function createProgram(
       'Custom name for the worktree branch'
     )
     .option(
-      '-a, --agent <agent...>',
-      `AI agent(s) to use - can be specified multiple times (${Object.values(AI_AGENT).join(', ')})`
+      '-a, --agent <agent>',
+      `AI agent to use. Use -a multiple times for parallel tasks (e.g., -a claude -a gemini). Available: ${Object.values(AI_AGENT).join(', ')}`,
+      (value: string, previous: string[] | undefined) =>
+        previous ? [...previous, value] : [value]
     )
     .option('--json', 'Output the result in JSON format')
     .option('--debug', 'Show debug information like running commands')


### PR DESCRIPTION
## Summary

The variadic option syntax `<agent...>` caused Commander.js to greedily consume all following arguments, including the task description.

**Before (broken):**
```bash
rover task -a gemini "my task"
# Error: Invalid agent: my task
```

The description "my task" was being parsed as a second agent value.

**After (fixed):**
```bash
rover task -a gemini "my task"  # ✓ Works
rover task -a gemini -a claude "my task"  # ✓ Multiple agents
```

## Changes

- Changed `-a, --agent <agent...>` to `-a, --agent <agent>` with an accumulator function
- Multiple agents now require repeated `-a` flags: `-a gemini -a claude`
- Improved help text to clarify usage

## Test plan

- [x] All existing tests pass
- [x] `rover task -a gemini "description"` correctly parses agent and description
- [x] `rover task -a gemini -a claude "description"` works for multiple agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)