### PR TITLE
feat: add configurable watch interval for list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ npm install -g @endorhq/rover@latest
    rover ls -w
    ```
 
+   You can specify a custom refresh interval (1-60 seconds):
+
+   ```sh
+   rover ls -w 10  # Refresh every 10 seconds
+   ```
+
+   Or set a default in `.rover/settings.json`:
+
+   ```json
+   {
+     "defaults": {
+       "watchIntervalSeconds": 5
+     }
+   }
+   ```
+
 4. Keep working on your own tasks 🤓
 
 5. After finishing, check the task result:

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -258,7 +258,7 @@ export function createProgram(
     .command('list')
     .alias('ls')
     .description('Show tasks and their status')
-    .option('-w, --watch', 'Watch for changes and refresh every 5 seconds')
+    .option('-w, --watch [seconds]', 'Watch for changes (default 3s, or specify interval)')
     .option('--json', 'Output in JSON format')
     .action(listCommand);
 

--- a/packages/core/src/files/user-settings.ts
+++ b/packages/core/src/files/user-settings.ts
@@ -166,6 +166,9 @@ export class UserSettingsManager {
   get defaultAiAgent(): AI_AGENT | undefined {
     return this.data.defaults.aiAgent;
   }
+  get watchIntervalSeconds(): number {
+    return this.data.defaults.watchIntervalSeconds ?? 3;
+  }
 
   // Data Modification (Setters)
   /**

--- a/packages/schemas/src/user-settings/schema.ts
+++ b/packages/schemas/src/user-settings/schema.ts
@@ -23,6 +23,8 @@ export const AiAgentSchema = z.enum(AI_AGENT);
 export const UserDefaultsSchema = z.object({
   /** Default AI agent to use */
   aiAgent: AiAgentSchema.optional(),
+  /** Watch interval in seconds for `rover list --watch` (default: 3) */
+  watchIntervalSeconds: z.number().min(1).max(60).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add `watchIntervalSeconds` setting to user defaults (1-60s range)
- The `rover list --watch` command now accepts an optional interval argument (e.g., `rover ls -w 10`)
- Falls back to settings file, then defaults to 3 seconds
- Fix: watch mode now works even when no tasks exist (previously returned early)
- Fix: help text incorrectly stated 5 seconds

## Usage

CLI argument (takes precedence):
```sh
rover ls -w 10  # Refresh every 10 seconds
```

Or configure in `.rover/settings.json`:
```json
{
  "defaults": {
    "watchIntervalSeconds": 5
  }
}
```

## Test plan
- [ ] Run `rover ls -w` with no tasks - should watch and refresh at default 3s interval
- [ ] Run `rover ls -w 10` - should refresh every 10 seconds
- [ ] Set `watchIntervalSeconds` in settings and run `rover ls -w` - should use configured interval
- [ ] CLI argument should override settings value

🤖 Generated with [Claude Code](https://claude.com/claude-code)