### PR TITLE
feat: support agent:model colon syntax for model selection

### DIFF
--- a/packages/agent/src/lib/agents/base.ts
+++ b/packages/agent/src/lib/agents/base.ts
@@ -7,9 +7,11 @@ export abstract class BaseAgent implements Agent {
   abstract name: string;
   abstract binary: string;
   version: string;
+  model?: string;
 
-  constructor(version: string = 'latest') {
+  constructor(version: string = 'latest', model?: string) {
     this.version = version;
+    this.model = model;
   }
 
   abstract getRequiredCredentials(): AgentCredentialFile[];

--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -21,6 +21,10 @@ export class ClaudeAgent extends BaseAgent {
   name = 'Claude';
   binary = 'claude';
 
+  constructor(version: string = 'latest', model?: string) {
+    super(version, model);
+  }
+
   getInstallCommand(): string {
     const packageSpec = `@anthropic-ai/claude-code@${this.version}`;
     return `npm install -g ${packageSpec}`;
@@ -160,7 +164,12 @@ export class ClaudeAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    return ['--dangerously-skip-permissions', '--output-format', 'json', '-p'];
+    const args = ['--dangerously-skip-permissions', '--output-format', 'json'];
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+    args.push('-p');
+    return args;
   }
 
   toolInteractiveArguments(

--- a/packages/agent/src/lib/agents/codex.ts
+++ b/packages/agent/src/lib/agents/codex.ts
@@ -9,6 +9,10 @@ export class CodexAgent extends BaseAgent {
   name = 'Codex';
   binary = 'codex';
 
+  constructor(version: string = 'latest', model?: string) {
+    super(version, model);
+  }
+
   getInstallCommand(): string {
     const packageSpec = `@openai/codex@${this.version}`;
     return `npm install -g ${packageSpec}`;
@@ -121,12 +125,16 @@ export class CodexAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    return [
+    const args = [
       'exec',
       '--dangerously-bypass-approvals-and-sandbox',
       '--skip-git-repo-check',
-      '-',
     ];
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+    args.push('-');
+    return args;
   }
 
   toolInteractiveArguments(

--- a/packages/agent/src/lib/agents/cursor.ts
+++ b/packages/agent/src/lib/agents/cursor.ts
@@ -11,6 +11,10 @@ export class CursorAgent extends BaseAgent {
   name = 'Cursor';
   binary = 'cursor-agent';
 
+  constructor(version: string = 'latest', model?: string) {
+    super(version, model);
+  }
+
   getInstallCommand(): string {
     return `nix build --no-link --accept-flake-config github:numtide/nix-ai-tools/${process.env.NIX_AI_TOOLS_REV}#cursor-agent`;
   }
@@ -147,7 +151,7 @@ export class CursorAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    return [
+    const args = [
       'agent',
       '--approve-mcps',
       '--browser',
@@ -156,6 +160,10 @@ export class CursorAgent extends BaseAgent {
       '--output-format',
       'json',
     ];
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+    return args;
   }
 
   toolInteractiveArguments(

--- a/packages/agent/src/lib/agents/gemini.ts
+++ b/packages/agent/src/lib/agents/gemini.ts
@@ -14,6 +14,10 @@ export class GeminiAgent extends BaseAgent {
   name = 'Gemini';
   binary = 'gemini';
 
+  constructor(version: string = 'latest', model?: string) {
+    super(version, model);
+  }
+
   getInstallCommand(): string {
     const packageSpec = `@google/gemini-cli@${this.version}`;
     return `npm install -g ${packageSpec}`;
@@ -116,7 +120,11 @@ export class GeminiAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    return ['--yolo', '--output-format', 'json'];
+    const args = ['--yolo', '--output-format', 'json'];
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+    return args;
   }
 
   toolInteractiveArguments(

--- a/packages/agent/src/lib/agents/index.ts
+++ b/packages/agent/src/lib/agents/index.ts
@@ -15,19 +15,20 @@ export { QwenAgent } from './qwen.js';
 
 export function createAgent(
   agentName: string,
-  version: string = 'latest'
+  version: string = 'latest',
+  model?: string
 ): Agent {
   switch (agentName.toLowerCase()) {
     case 'claude':
-      return new ClaudeAgent(version);
+      return new ClaudeAgent(version, model);
     case 'codex':
-      return new CodexAgent(version);
+      return new CodexAgent(version, model);
     case 'cursor':
-      return new CursorAgent(version);
+      return new CursorAgent(version, model);
     case 'gemini':
-      return new GeminiAgent(version);
+      return new GeminiAgent(version, model);
     case 'qwen':
-      return new QwenAgent(version);
+      return new QwenAgent(version, model);
     default:
       throw new Error(
         `Unknown agent: ${agentName}. Supported agents: ${Object.values(AI_AGENT).join(', ')}`

--- a/packages/agent/src/lib/agents/qwen.ts
+++ b/packages/agent/src/lib/agents/qwen.ts
@@ -9,6 +9,10 @@ export class QwenAgent extends BaseAgent {
   name = 'Qwen';
   binary = 'qwen';
 
+  constructor(version: string = 'latest', model?: string) {
+    super(version, model);
+  }
+
   getInstallCommand(): string {
     const packageSpec = `@qwen-code/qwen-code@${this.version}`;
     return `npm install -g ${packageSpec}`;
@@ -111,7 +115,12 @@ export class QwenAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    return ['--yolo', '-p'];
+    const args = ['--yolo'];
+    if (this.model) {
+      args.push('--model', this.model);
+    }
+    args.push('-p');
+    return args;
   }
 
   toolInteractiveArguments(

--- a/packages/agent/src/lib/runner.ts
+++ b/packages/agent/src/lib/runner.ts
@@ -123,7 +123,7 @@ export class Runner {
 
     if (availableTool) {
       this.tool = availableTool;
-      this.agent = createAgent(availableTool);
+      this.agent = createAgent(availableTool, 'latest', this.defaultModel);
     } else {
       throw new Error(`Could not find any tool to run the '${stepId}' step`);
     }

--- a/packages/cli/src/lib/agent-models.ts
+++ b/packages/cli/src/lib/agent-models.ts
@@ -1,0 +1,108 @@
+/**
+ * Model definitions for each AI agent.
+ * Used for model selection in init and CLI help text.
+ */
+import { AI_AGENT } from 'rover-core';
+
+export interface AgentModelConfig {
+  /** Model identifier (e.g., "opus", "sonnet", "flash") */
+  name: string;
+  /** Human-readable description */
+  description: string;
+  /** Whether this is the default model for the agent */
+  isDefault?: boolean;
+}
+
+/**
+ * Available models for each AI agent.
+ * Models are listed in order of preference (default first).
+ */
+export const AGENT_MODELS: Record<AI_AGENT, AgentModelConfig[]> = {
+  [AI_AGENT.Claude]: [
+    {
+      name: 'sonnet',
+      description: 'Balanced performance and cost',
+      isDefault: true,
+    },
+    { name: 'opus', description: 'Highest capability' },
+    { name: 'haiku', description: 'Fastest and cheapest' },
+  ],
+  [AI_AGENT.Gemini]: [
+    {
+      name: 'flash',
+      description: 'Balance of speed and reasoning',
+      isDefault: true,
+    },
+    { name: 'pro', description: 'Deep reasoning and creativity' },
+    { name: 'flash-lite', description: 'Fast and lightweight' },
+  ],
+  [AI_AGENT.Qwen]: [
+    {
+      name: 'coder-model',
+      description: 'Coding-optimized model',
+      isDefault: true,
+    },
+  ],
+  [AI_AGENT.Codex]: [
+    {
+      name: 'gpt-5.1-codex-max',
+      description: 'Codex-optimized flagship for deep reasoning',
+      isDefault: true,
+    },
+    { name: 'gpt-5.1-codex', description: 'Optimized for codex' },
+    {
+      name: 'gpt-5.1-codex-mini',
+      description: 'Faster and cheaper codex model',
+    },
+    { name: 'gpt-5.2', description: 'Latest frontier model' },
+    { name: 'gpt-5.1', description: 'Strong general reasoning' },
+  ],
+  [AI_AGENT.Cursor]: [
+    { name: 'auto', description: 'Automatic model selection', isDefault: true },
+    { name: 'sonnet-4.5', description: 'Claude 4.5 Sonnet' },
+    {
+      name: 'sonnet-4.5-thinking',
+      description: 'Claude 4.5 Sonnet (Thinking)',
+    },
+    { name: 'opus-4.5', description: 'Claude 4.5 Opus' },
+    { name: 'opus-4.5-thinking', description: 'Claude 4.5 Opus (Thinking)' },
+    { name: 'opus-4.1', description: 'Claude 4.1 Opus' },
+    { name: 'gemini-3-pro', description: 'Gemini 3 Pro' },
+    { name: 'gemini-3-flash', description: 'Gemini 3 Flash' },
+    { name: 'gpt-5.2', description: 'GPT-5.2' },
+    { name: 'gpt-5.1', description: 'GPT-5.1' },
+    { name: 'grok', description: 'Grok' },
+  ],
+};
+
+/**
+ * Get available models for a specific agent.
+ */
+export function getAvailableModels(agent: AI_AGENT): AgentModelConfig[] {
+  return AGENT_MODELS[agent] || [];
+}
+
+/**
+ * Get the default model name for a specific agent.
+ */
+export function getDefaultModelName(agent: AI_AGENT): string | undefined {
+  const models = AGENT_MODELS[agent];
+  return models?.find(m => m.isDefault)?.name;
+}
+
+/**
+ * Check if an agent has multiple model options.
+ * Used to determine whether to show model selection in init.
+ */
+export function hasMultipleModels(agent: AI_AGENT): boolean {
+  return (AGENT_MODELS[agent]?.length || 0) > 1;
+}
+
+/**
+ * Get agents that have multiple model options.
+ */
+export function getAgentsWithMultipleModels(): AI_AGENT[] {
+  return Object.entries(AGENT_MODELS)
+    .filter(([, models]) => models.length > 1)
+    .map(([agent]) => agent as AI_AGENT);
+}

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -183,6 +183,11 @@ export class DockerSandbox extends Sandbox {
       '/inputs.json'
     );
 
+    // Pass model if specified
+    if (this.task.agentModel) {
+      dockerArgs.push('--agent-model', this.task.agentModel);
+    }
+
     // Forward verbose flag to rover-agent if enabled
     if (VERBOSE) {
       dockerArgs.push('-v');
@@ -321,6 +326,11 @@ export class DockerSandbox extends Sandbox {
 
     if (initialPrompt) {
       dockerArgs.push(initialPrompt);
+    }
+
+    // Pass model if specified
+    if (this.task.agentModel) {
+      dockerArgs.push('--agent-model', this.task.agentModel);
     }
 
     // Forward verbose flag to rover-agent if enabled

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -163,6 +163,11 @@ export class PodmanSandbox extends Sandbox {
       '/inputs.json'
     );
 
+    // Pass model if specified
+    if (this.task.agentModel) {
+      podmanArgs.push('--agent-model', this.task.agentModel);
+    }
+
     // Forward verbose flag to rover-agent if enabled
     if (VERBOSE) {
       podmanArgs.push('-v');
@@ -286,6 +291,11 @@ export class PodmanSandbox extends Sandbox {
 
     if (initialPrompt) {
       podmanArgs.push(initialPrompt);
+    }
+
+    // Pass model if specified
+    if (this.task.agentModel) {
+      podmanArgs.push('--agent-model', this.task.agentModel);
     }
 
     // Forward verbose flag to rover-agent if enabled

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -216,7 +216,7 @@ export function createProgram(
     )
     .option(
       '-a, --agent <agent>',
-      `AI agent to use. Use -a multiple times for parallel tasks (e.g., -a claude -a gemini). Available: ${Object.values(AI_AGENT).join(', ')}`,
+      `AI agent with optional model (e.g., claude:opus, gemini:flash). Repeat for multiple agents. Available: ${Object.values(AI_AGENT).join(', ')}`,
       (value: string, previous: string[] | undefined) =>
         previous ? [...previous, value] : [value]
     )

--- a/packages/cli/src/utils/__tests__/agent-parser.test.ts
+++ b/packages/cli/src/utils/__tests__/agent-parser.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { parseAgentString, formatAgentWithModel } from '../agent-parser.js';
+import { AI_AGENT } from 'rover-core';
+
+describe('parseAgentString', () => {
+  describe('parsing agent without model', () => {
+    it('should parse "claude" as claude agent with no model', () => {
+      const result = parseAgentString('claude');
+      expect(result.agent).toBe(AI_AGENT.Claude);
+      expect(result.model).toBeUndefined();
+    });
+
+    it('should parse "gemini" as gemini agent with no model', () => {
+      const result = parseAgentString('gemini');
+      expect(result.agent).toBe(AI_AGENT.Gemini);
+      expect(result.model).toBeUndefined();
+    });
+
+    it('should parse "qwen" as qwen agent with no model', () => {
+      const result = parseAgentString('qwen');
+      expect(result.agent).toBe(AI_AGENT.Qwen);
+      expect(result.model).toBeUndefined();
+    });
+
+    it('should parse "codex" as codex agent with no model', () => {
+      const result = parseAgentString('codex');
+      expect(result.agent).toBe(AI_AGENT.Codex);
+      expect(result.model).toBeUndefined();
+    });
+
+    it('should parse "cursor" as cursor agent with no model', () => {
+      const result = parseAgentString('cursor');
+      expect(result.agent).toBe(AI_AGENT.Cursor);
+      expect(result.model).toBeUndefined();
+    });
+  });
+
+  describe('parsing agent with model', () => {
+    it('should parse "claude:opus" correctly', () => {
+      const result = parseAgentString('claude:opus');
+      expect(result.agent).toBe(AI_AGENT.Claude);
+      expect(result.model).toBe('opus');
+    });
+
+    it('should parse "claude:sonnet" correctly', () => {
+      const result = parseAgentString('claude:sonnet');
+      expect(result.agent).toBe(AI_AGENT.Claude);
+      expect(result.model).toBe('sonnet');
+    });
+
+    it('should parse "claude:haiku" correctly', () => {
+      const result = parseAgentString('claude:haiku');
+      expect(result.agent).toBe(AI_AGENT.Claude);
+      expect(result.model).toBe('haiku');
+    });
+
+    it('should parse "gemini:flash" correctly', () => {
+      const result = parseAgentString('gemini:flash');
+      expect(result.agent).toBe(AI_AGENT.Gemini);
+      expect(result.model).toBe('flash');
+    });
+
+    it('should parse "gemini:pro" correctly', () => {
+      const result = parseAgentString('gemini:pro');
+      expect(result.agent).toBe(AI_AGENT.Gemini);
+      expect(result.model).toBe('pro');
+    });
+
+    it('should parse "qwen:plus" correctly', () => {
+      const result = parseAgentString('qwen:plus');
+      expect(result.agent).toBe(AI_AGENT.Qwen);
+      expect(result.model).toBe('plus');
+    });
+
+    it('should handle model names with hyphens', () => {
+      const result = parseAgentString('gemini:flash-2.0');
+      expect(result.agent).toBe(AI_AGENT.Gemini);
+      expect(result.model).toBe('flash-2.0');
+    });
+
+    it('should handle model names with colons by joining them', () => {
+      const result = parseAgentString('claude:some:model:name');
+      expect(result.agent).toBe(AI_AGENT.Claude);
+      expect(result.model).toBe('some:model:name');
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('should parse "CLAUDE" as claude', () => {
+      const result = parseAgentString('CLAUDE');
+      expect(result.agent).toBe(AI_AGENT.Claude);
+    });
+
+    it('should parse "Claude" as claude', () => {
+      const result = parseAgentString('Claude');
+      expect(result.agent).toBe(AI_AGENT.Claude);
+    });
+
+    it('should parse "GEMINI:PRO" correctly', () => {
+      const result = parseAgentString('GEMINI:PRO');
+      expect(result.agent).toBe(AI_AGENT.Gemini);
+      expect(result.model).toBe('PRO');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw error for invalid agent', () => {
+      expect(() => parseAgentString('invalid')).toThrow('Invalid agent');
+    });
+
+    it('should throw error for empty string', () => {
+      expect(() => parseAgentString('')).toThrow('Invalid agent');
+    });
+
+    it('should throw error for unknown agent with model', () => {
+      expect(() => parseAgentString('unknown:model')).toThrow('Invalid agent');
+    });
+  });
+});
+
+describe('formatAgentWithModel', () => {
+  it('should format agent without model', () => {
+    const result = formatAgentWithModel(AI_AGENT.Claude);
+    expect(result).toBe('claude');
+  });
+
+  it('should format agent with undefined model', () => {
+    const result = formatAgentWithModel(AI_AGENT.Claude, undefined);
+    expect(result).toBe('claude');
+  });
+
+  it('should format agent with model', () => {
+    const result = formatAgentWithModel(AI_AGENT.Claude, 'opus');
+    expect(result).toBe('claude:opus');
+  });
+
+  it('should format gemini with model', () => {
+    const result = formatAgentWithModel(AI_AGENT.Gemini, 'flash');
+    expect(result).toBe('gemini:flash');
+  });
+});

--- a/packages/cli/src/utils/agent-parser.ts
+++ b/packages/cli/src/utils/agent-parser.ts
@@ -1,0 +1,71 @@
+/**
+ * Utility for parsing agent strings with optional model specification.
+ * Supports the colon syntax: "agent" or "agent:model"
+ * Examples: "claude", "claude:opus", "gemini:flash"
+ */
+import { AI_AGENT } from 'rover-core';
+
+export interface ParsedAgent {
+  agent: AI_AGENT;
+  model?: string;
+}
+
+/**
+ * Parse an agent string with optional model specification.
+ * Format: "agent" or "agent:model"
+ *
+ * @param agentString - The agent string to parse (e.g., "claude:opus")
+ * @returns Parsed agent object with agent name and optional model
+ * @throws Error if the agent name is invalid
+ *
+ * @example
+ * parseAgentString("claude") // { agent: "claude", model: undefined }
+ * parseAgentString("claude:opus") // { agent: "claude", model: "opus" }
+ * parseAgentString("gemini:flash-2.0") // { agent: "gemini", model: "flash-2.0" }
+ */
+export function parseAgentString(agentString: string): ParsedAgent {
+  const parts = agentString.split(':');
+  const agentName = parts[0].toLowerCase();
+  // Join remaining parts with ':' in case model name contains colons
+  const model = parts.length > 1 ? parts.slice(1).join(':') : undefined;
+
+  // Validate and normalize agent name
+  let normalizedAgent: AI_AGENT;
+  switch (agentName) {
+    case 'claude':
+      normalizedAgent = AI_AGENT.Claude;
+      break;
+    case 'codex':
+      normalizedAgent = AI_AGENT.Codex;
+      break;
+    case 'cursor':
+      normalizedAgent = AI_AGENT.Cursor;
+      break;
+    case 'gemini':
+      normalizedAgent = AI_AGENT.Gemini;
+      break;
+    case 'qwen':
+      normalizedAgent = AI_AGENT.Qwen;
+      break;
+    default:
+      throw new Error(
+        `Invalid agent: ${agentName}. Valid options are: ${Object.values(AI_AGENT).join(', ')}`
+      );
+  }
+
+  return {
+    agent: normalizedAgent,
+    model: model || undefined,
+  };
+}
+
+/**
+ * Format an agent with its model for display.
+ *
+ * @param agent - The AI agent
+ * @param model - Optional model name
+ * @returns Formatted string (e.g., "claude:opus" or "claude")
+ */
+export function formatAgentWithModel(agent: AI_AGENT, model?: string): string {
+  return model ? `${agent}:${model}` : agent;
+}

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -68,6 +68,7 @@ export class TaskDescriptionManager {
       workflowName: taskData.workflowName,
       branchName: '',
       agent: taskData.agent,
+      agentModel: taskData.agentModel,
       sourceBranch: taskData.sourceBranch,
       version: CURRENT_TASK_DESCRIPTION_SCHEMA_VERSION,
     };
@@ -199,8 +200,9 @@ export class TaskDescriptionManager {
     migrated.restartCount = data.restartCount || 0;
     migrated.lastRestartAt = data.lastRestartAt || undefined;
 
-    // Preserve agent and sourceBranch fields
+    // Preserve agent, agentModel, and sourceBranch fields
     migrated.agent = data.agent;
+    migrated.agentModel = data.agentModel;
     migrated.sourceBranch = data.sourceBranch;
 
     // Preserve agentImage field
@@ -599,6 +601,9 @@ export class TaskDescriptionManager {
   }
   get agent(): string | undefined {
     return this.data.agent;
+  }
+  get agentModel(): string | undefined {
+    return this.data.agentModel;
   }
   get sourceBranch(): string | undefined {
     return this.data.sourceBranch;

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -44,6 +44,7 @@ export const TaskDescriptionSchema = z.object({
   worktreePath: z.string(),
   branchName: z.string(),
   agent: z.string().optional(),
+  agentModel: z.string().optional(),
   sourceBranch: z.string().optional(),
 
   // Docker Execution

--- a/packages/schemas/src/task-description/types.ts
+++ b/packages/schemas/src/task-description/types.ts
@@ -20,6 +20,7 @@ export interface CreateTaskData {
   workflowName: string;
   uuid?: string; // Optional, will be generated if not provided
   agent?: string; // AI agent to use for execution
+  agentModel?: string; // AI model to use (e.g., opus, sonnet, flash)
   sourceBranch?: string; // Source branch task was created from
 }
 


### PR DESCRIPTION
## Summary
- Add support for specifying AI agent models using colon syntax (e.g., `-a claude:opus`, `-a gemini:flash`)
- Parse agent:model format in CLI and store model in task description
- Pass model through to rover-agent and underlying AI tools

## Changes
- `packages/cli/src/utils/agent-parser.ts` - New parser for "agent:model" format
- `packages/cli/src/lib/agent-models.ts` - Model definitions for each agent
- `packages/cli/src/commands/task.ts` - Parse agent strings and store model
- `packages/schemas/src/task-description/` - Add agentModel field
- `packages/agent/src/lib/agents/` - Update all agents to accept and use model parameter
- `packages/cli/src/lib/sandbox/` - Pass --agent-model flag to rover-agent

## Test plan
- [ ] Run `rover task -a claude:opus "test task"` and verify model is stored
- [ ] Run `rover task -a gemini:flash "test task"` and verify different agent/model
- [ ] Verify backward compatibility with `-a claude` (no model specified)

🤖 Generated with [Claude Code](https://claude.ai/code)