### PR TITLE
feat: add per-step workflow tool/model overrides with -o flag

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -59,6 +59,10 @@ program
     'Agent model to use. It overrides defaults, but prioritize step tools if available.'
   )
   .option(
+    '--step-agents <json>',
+    'JSON object mapping step IDs to {tool, model} overrides'
+  )
+  .option(
     '--task-id <id>',
     'Task ID for status tracking (required if --status-file is provided)'
   )

--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -18,6 +18,8 @@ interface RunCommandOptions {
   agentTool?: string;
   // Model to use instead of workflow defaults
   agentModel?: string;
+  // Per-step agent/model overrides (JSON string)
+  stepAgents?: string;
   // Task ID for status tracking
   taskId?: string;
   // Path to status.json file
@@ -277,6 +279,20 @@ export const runCommand = async (
       let runSteps = 0;
       const totalSteps = workflowManager.steps.length;
 
+      // Parse step agents if provided
+      let parsedStepAgents:
+        | Record<string, { tool?: string; model?: string }>
+        | undefined;
+      if (options.stepAgents) {
+        try {
+          parsedStepAgents = JSON.parse(options.stepAgents);
+        } catch (err) {
+          console.log(colors.red(`\n✗ Invalid step-agents JSON: ${err}`));
+          output.error = `Invalid step-agents JSON: ${err}`;
+          return;
+        }
+      }
+
       for (
         let stepIndex = 0;
         stepIndex < workflowManager.steps.length;
@@ -292,7 +308,8 @@ export const runCommand = async (
           options.agentModel,
           statusManager,
           totalSteps,
-          stepIndex
+          stepIndex,
+          parsedStepAgents
         );
 
         runSteps++;

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -188,6 +188,11 @@ export class DockerSandbox extends Sandbox {
       dockerArgs.push('--agent-model', this.task.agentModel);
     }
 
+    // Pass step agents configuration if specified
+    if (this.task.stepAgents && Object.keys(this.task.stepAgents).length > 0) {
+      dockerArgs.push('--step-agents', JSON.stringify(this.task.stepAgents));
+    }
+
     // Forward verbose flag to rover-agent if enabled
     if (VERBOSE) {
       dockerArgs.push('-v');

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -168,6 +168,11 @@ export class PodmanSandbox extends Sandbox {
       podmanArgs.push('--agent-model', this.task.agentModel);
     }
 
+    // Pass step agents configuration if specified
+    if (this.task.stepAgents && Object.keys(this.task.stepAgents).length > 0) {
+      podmanArgs.push('--step-agents', JSON.stringify(this.task.stepAgents));
+    }
+
     // Forward verbose flag to rover-agent if enabled
     if (VERBOSE) {
       podmanArgs.push('-v');

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -220,6 +220,12 @@ export function createProgram(
       (value: string, previous: string[] | undefined) =>
         previous ? [...previous, value] : [value]
     )
+    .option(
+      '-o, --override <step:tool[:model]>',
+      'Override tool/model for specific workflow steps (e.g., -o implement:claude:opus -o context:gemini)',
+      (value: string, previous: string[] | undefined) =>
+        previous ? [...previous, value] : [value]
+    )
     .option('--json', 'Output the result in JSON format')
     .option('--debug', 'Show debug information like running commands')
     .argument(

--- a/packages/cli/src/utils/step-agent-parser.ts
+++ b/packages/cli/src/utils/step-agent-parser.ts
@@ -1,0 +1,98 @@
+/**
+ * Utility for parsing step agent strings in the format "step:tool:model" or "step:tool"
+ */
+
+import { AI_AGENT } from 'rover-core';
+
+export interface ParsedStepAgent {
+  stepId: string;
+  tool: string;
+  model?: string;
+}
+
+/**
+ * Parse a step agent string in the format "step:tool" or "step:tool:model"
+ * @param input - The input string to parse (e.g., "implement:claude:opus" or "context:gemini")
+ * @returns Parsed step agent configuration
+ * @throws Error if the format is invalid
+ */
+export function parseStepAgentString(input: string): ParsedStepAgent {
+  const parts = input.split(':');
+
+  if (parts.length < 2) {
+    throw new Error(
+      `Invalid step-agent format: "${input}". Expected "step:tool" or "step:tool:model"`
+    );
+  }
+
+  const stepId = parts[0].trim();
+  const tool = parts[1].trim();
+  const model = parts.length > 2 ? parts.slice(2).join(':').trim() : undefined;
+
+  if (!stepId) {
+    throw new Error(
+      `Invalid step-agent format: "${input}". Step ID cannot be empty`
+    );
+  }
+
+  if (!tool) {
+    throw new Error(
+      `Invalid step-agent format: "${input}". Tool cannot be empty`
+    );
+  }
+
+  // Validate tool is a known AI agent
+  const normalizedTool = tool.toLowerCase();
+  const validAgents = Object.values(AI_AGENT).map(a => a.toLowerCase());
+
+  if (!validAgents.includes(normalizedTool)) {
+    throw new Error(
+      `Invalid tool "${tool}" in step-agent "${input}". Valid tools: ${Object.values(AI_AGENT).join(', ')}`
+    );
+  }
+
+  return {
+    stepId,
+    tool: normalizedTool,
+    model: model || undefined,
+  };
+}
+
+/**
+ * Validate that all step IDs in the parsed step agents are valid for the given workflow
+ * @param stepAgents - Array of parsed step agents
+ * @param validStepIds - Array of valid step IDs for the workflow
+ * @throws Error if any step ID is invalid
+ */
+export function validateStepIds(
+  stepAgents: ParsedStepAgent[],
+  validStepIds: string[]
+): void {
+  for (const sa of stepAgents) {
+    if (!validStepIds.includes(sa.stepId)) {
+      throw new Error(
+        `Invalid step ID "${sa.stepId}". Valid steps for this workflow: ${validStepIds.join(', ')}`
+      );
+    }
+  }
+}
+
+/**
+ * Convert an array of parsed step agents to a record for storage
+ * @param stepAgents - Array of parsed step agents
+ * @returns Record mapping step ID to tool/model config
+ */
+export function stepAgentsToRecord(
+  stepAgents: ParsedStepAgent[]
+): Record<string, { tool?: string; model?: string }> {
+  const record: Record<string, { tool?: string; model?: string }> = {};
+
+  for (const sa of stepAgents) {
+    record[sa.stepId] = {
+      tool: sa.tool,
+      model: sa.model,
+    };
+  }
+
+  return record;
+}

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -70,6 +70,7 @@ export class TaskDescriptionManager {
       agent: taskData.agent,
       agentModel: taskData.agentModel,
       sourceBranch: taskData.sourceBranch,
+      stepAgents: taskData.stepAgents,
       version: CURRENT_TASK_DESCRIPTION_SCHEMA_VERSION,
     };
 
@@ -200,9 +201,10 @@ export class TaskDescriptionManager {
     migrated.restartCount = data.restartCount || 0;
     migrated.lastRestartAt = data.lastRestartAt || undefined;
 
-    // Preserve agent, agentModel, and sourceBranch fields
+    // Preserve agent, agentModel, stepAgents, and sourceBranch fields
     migrated.agent = data.agent;
     migrated.agentModel = data.agentModel;
+    migrated.stepAgents = data.stepAgents;
     migrated.sourceBranch = data.sourceBranch;
 
     // Preserve agentImage field
@@ -604,6 +606,11 @@ export class TaskDescriptionManager {
   }
   get agentModel(): string | undefined {
     return this.data.agentModel;
+  }
+  get stepAgents():
+    | Record<string, { tool?: string; model?: string }>
+    | undefined {
+    return this.data.stepAgents;
   }
   get sourceBranch(): string | undefined {
     return this.data.sourceBranch;

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -47,6 +47,17 @@ export const TaskDescriptionSchema = z.object({
   agentModel: z.string().optional(),
   sourceBranch: z.string().optional(),
 
+  // Per-step agent/model overrides (step ID -> { tool, model })
+  stepAgents: z
+    .record(
+      z.string(),
+      z.object({
+        tool: z.string().optional(),
+        model: z.string().optional(),
+      })
+    )
+    .optional(),
+
   // Docker Execution
   containerId: z.string().optional(),
   executionStatus: z.string().optional(),

--- a/packages/schemas/src/task-description/types.ts
+++ b/packages/schemas/src/task-description/types.ts
@@ -11,6 +11,12 @@ export type TaskStatus = z.infer<typeof TaskStatusSchema>;
 // Infer TaskDescriptionSchema type from Zod schema
 export type TaskDescription = z.infer<typeof TaskDescriptionSchema>;
 
+// Per-step agent/model configuration
+export interface StepAgentConfig {
+  tool?: string;
+  model?: string;
+}
+
 // Data required to create a new task
 export interface CreateTaskData {
   id: number;
@@ -22,6 +28,7 @@ export interface CreateTaskData {
   agent?: string; // AI agent to use for execution
   agentModel?: string; // AI model to use (e.g., opus, sonnet, flash)
   sourceBranch?: string; // Source branch task was created from
+  stepAgents?: Record<string, StepAgentConfig>; // Per-step agent/model overrides
 }
 
 // Metadata for status updates


### PR DESCRIPTION
## Summary
- Add `-o` flag to override AI agent tool and/or model for specific workflow steps
- Allows using different agents for different steps in a single task

## Usage
```bash
rover task -o implement:claude:opus -o context:gemini "task description"
```

## Changes
- `packages/cli/src/utils/step-agent-parser.ts` - Parse "step:tool[:model]" format
- `packages/cli/src/program.ts` - Add -o/--override flag
- `packages/cli/src/commands/task.ts` - Parse and validate step overrides
- `packages/schemas/src/task-description/` - Add stepAgents field
- `packages/cli/src/lib/sandbox/` - Pass --step-agents to rover-agent
- `packages/agent/src/cli.ts` - Add --step-agents option
- `packages/agent/src/lib/runner.ts` - Use step-specific tool/model overrides

## Test plan
- [ ] Run `rover task -o implement:gemini "test"` and verify implement step uses gemini
- [ ] Run `rover task -o context:claude:opus -o implement:gemini:flash "test"` with multiple overrides
- [ ] Verify invalid step IDs are rejected with helpful error message

🤖 Generated with [Claude Code](https://claude.ai/code)