### PR TITLE
fix: build the agent image using pnpm

### DIFF
--- a/images/agent/Dockerfile
+++ b/images/agent/Dockerfile
@@ -3,9 +3,12 @@ FROM node:24-alpine AS agent-builder
 COPY . /app
 WORKDIR /app
 
+# Load corepack
+RUN corepack enable pnpm
+
 # Build the agent
-RUN npm install && npm run build:agent
-RUN cd ./packages/agent && npm pack && mv *.tgz /rover-agent.tgz
+RUN pnpm install && pnpm build-libs && pnpm --filter @endorhq/agent build
+RUN cd ./packages/agent && pnpm pack && mv *.tgz /rover-agent.tgz
 
 FROM node:24-alpine
 ARG NIX_AI_TOOLS_REV

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "pnpm --filter './packages/*' -r --parallel dev",
     "build": "pnpm -r --filter './packages/*' build",
+    "build-libs": "pnpm -r --filter './packages/schemas' --filter './packages/telemetry' --filter './packages/core' build",
     "build-dev": "pnpm -r --filter './packages/*' build-dev",
     "package": "pnpm -r --filter './packages/*' package",
     "check": "pnpm -r --filter './packages/*' check",


### PR DESCRIPTION
Fixes the agent Docker image build to use pnpm instead of npm, aligning with the recent migration to pnpm as the package manager.

## Changes

- Updated `images/agent/Dockerfile` to enable corepack and use pnpm for package installation and building
- Added `build-libs` script to `package.json` to build library dependencies (`schemas`, `telemetry`, `core`) that the agent package requires