### PR TITLE
fix: replace rmdirSync with rmSync for Node.js 22+ compatibility

### DIFF
--- a/packages/core/src/project/project.ts
+++ b/packages/core/src/project/project.ts
@@ -1,6 +1,6 @@
 import { isAbsolute, join, resolve } from 'node:path';
 import { getDataDir } from '../paths.js';
-import { existsSync, mkdirSync, rmdirSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { GlobalProject } from 'rover-schemas';
 import { createHash } from 'node:crypto';
 import { detectEnvironment } from './environment.js';
@@ -217,7 +217,7 @@ export class ProjectManager {
       return;
     }
 
-    rmdirSync(join(this.projectsPath, id), { recursive: true });
+    rmSync(join(this.projectsPath, id), { recursive: true });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace `fs.rmdirSync` with `fs.rmSync` in `packages/core/src/project/project.ts`

The `recursive` option on `fs.rmdirSync` was deprecated in Node.js 14 (DEP0147) and fully removed in Node.js 22+, causing test failures on CI for the `build (22.x)` job.

## Test plan

- [x] `pnpm test` passes locally on Node.js 25.1.0
- [x] Verified the failing test `ProjectManager > remove > should delete project folders when they exist` now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)