### PR TITLE
fix: use source to export types in private libs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rover-core",
   "version": "1.0.0",
+  "private": true,
   "description": "Provide common logic for the CLI and the VSCode extension",
   "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "types": "src/index.ts",
   "type": "module",
   "files": ["LICENSE.md", "dist/*"],
   "scripts": {

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Define project file schemas and utilities to manage them",
   "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "types": "src/index.ts",
   "type": "module",
   "files": ["LICENSE.md", "dist/*"],
   "scripts": {

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,9 +1,10 @@
 {
   "name": "rover-telemetry",
   "version": "1.0.0",
+  "private": true,
   "description": "Provide basic telemetry to the rover CLI and extension",
   "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "types": "src/index.ts",
   "type": "module",
   "files": ["LICENSE.md", "dist/*"],
   "scripts": {


### PR DESCRIPTION
Enables TypeScript type checking (`pnpm check`) to work without requiring the library packages to be built first. This fixes the issue where running `tsc --noEmit` in consumer packages (core, cli, agent) would fail because they tried to import types from `dist/index.d.mts` which doesn't exist until the libraries are built.

The solution points the `types` field directly to the TypeScript source files (`src/index.ts`) instead of the compiled declaration files. This is safe because these are private workspace packages that are never published to npm.

## Changes

- Changed `types` field from `dist/index.d.mts` to `src/index.ts` in `rover-schemas`, `rover-telemetry`, and `rover-core`
- Marked `rover-core` and `rover-telemetry` as `private: true` for consistency with `rover-schemas`

## Notes

An alternative approach would be to use pnpm's `publishConfig` option to override the `types` field during publishing. However, since these packages are private and not published to npm, pointing types directly to source is simpler and achieves the same goal without additional configuration complexity.