### PR TITLE
feat(cli): show model name in task list agent column

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -233,10 +233,16 @@ export const listCommand = async (
 
       const iterationStatus = maybeIterationStatus(lastIteration);
 
+      // Format agent with model (e.g., "claude:sonnet")
+      let agentDisplay = task.agent || '-';
+      if (task.agent && task.agentModel) {
+        agentDisplay = `${task.agent}:${task.agentModel}`;
+      }
+
       return {
         id: task.id.toString(),
         title: task.title || 'Unknown Task',
-        agent: task.agent || '-',
+        agent: agentDisplay,
         workflow: task.workflowName || '-',
         status: taskStatus,
         progress: iterationStatus?.progress || 0,
@@ -264,7 +270,9 @@ export const listCommand = async (
       {
         header: 'Agent',
         key: 'agent',
-        width: 8,
+        minWidth: 8,
+        maxWidth: 16,
+        truncate: 'ellipsis',
         format: (value: string) => colors.gray(value),
       },
       {


### PR DESCRIPTION
## Summary
- Display the agent model alongside the agent name in the `rover list` output (e.g., "claude:sonnet" instead of just "claude")
- Adjusted Agent column to use `minWidth: 8` / `maxWidth: 16` with ellipsis truncation to accommodate longer strings

## Test plan
- [x] Existing tests pass (`pnpm test`)
- [ ] Manual testing: Run `rover list` with tasks using different agent models and verify the format displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)