### PR TITLE
feat: mount .claude/settings.json file to load user preferences

### DIFF
--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -59,6 +59,13 @@ export class ClaudeAgent extends BaseAgent {
       });
     }
 
+    // Claude settings.json for user preferences (optional)
+    requiredCredentials.push({
+      path: '/.settings.json',
+      description: 'Claude settings',
+      required: false,
+    });
+
     return requiredCredentials;
   }
 
@@ -100,6 +107,12 @@ export class ClaudeAgent extends BaseAgent {
             recursive: true,
           });
           console.log(colors.gray('├── Copied: ') + colors.cyan(cred.path));
+        } else if (cred.path.includes('.settings.json')) {
+          // Copy settings.json to .claude directory
+          copyFileSync(cred.path, join(targetClaudeDir, 'settings.json'));
+          console.log(
+            colors.gray('├── Copied: ') + colors.cyan('settings.json')
+          );
         } else {
           // Copy file right away
           copyFileSync(cred.path, join(targetClaudeDir, filename));

--- a/packages/cli/src/lib/agents/claude.ts
+++ b/packages/cli/src/lib/agents/claude.ts
@@ -265,6 +265,12 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
       // TODO: mount bedrock credentials
     }
 
+    // Mount Claude settings.json if it exists (optional - for user preferences like default model)
+    const claudeSettings = join(homedir(), '.claude', 'settings.json');
+    if (existsSync(claudeSettings)) {
+      dockerMounts.push(`-v`, `${claudeSettings}:/.settings.json:Z,ro`);
+    }
+
     return dockerMounts;
   }
 


### PR DESCRIPTION
Adds support for loading the user's `~/.claude/settings.json` file when running Claude tasks. This ensures user preferences like the default model are respected inside the container.

Closes #407

## Changes

- Mount `~/.claude/settings.json` as a read-only volume in the Docker container when present
- Add `/.settings.json` to the list of optional credentials to copy inside the container
- Copy the settings file to the `.claude` directory so Claude Code can read it during task execution