### PR TITLE
feat: test the CLI build against all LTS and active Node versions

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -11,8 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      # From https://nodejs.org/en/about/previous-releases
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Expand the CLI CI workflow to test against all currently supported Node.js versions, ensuring compatibility across the full range of LTS and active releases.

## Changes

- Added Node.js 24.x and 25.x to the test matrix in `.github/workflows/cli.yml`
- Added a reference comment to the Node.js previous releases page for easy version tracking

## Notes

The matrix now tests against:
- **20.x** - LTS (Maintenance)
- **22.x** - LTS (Active) 
- **24.x** - Current
- **25.x** - Active development