### PR TITLE
chore: resolve workflow names later after commander.js parses the name of the workflow

### DIFF
--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -148,9 +148,7 @@ export function createProgram(
       new Option(
         '--workflow, -w <name>',
         'Use a specific workflow to complete this task'
-      )
-        .choices(['swe', 'tech-writer'])
-        .default('swe')
+      ).default('swe')
     )
     .option('-y, --yes', 'Skip all confirmations and run non-interactively')
     .option(


### PR DESCRIPTION
Remove the hardcoded workflow choices from the CLI option definition, allowing workflow names to be validated at runtime after commander.js parses the input. This change improves flexibility in workflow handling.

## Changes

- Removed `.choices(['swe', 'tech-writer'])` constraint from the `--workflow` option in `packages/cli/src/program.ts`
- Kept the default workflow value as `'swe'`
- Workflow name validation now occurs later in the command execution flow

## Notes

This change enables more dynamic workflow resolution and validation, allowing the system to determine valid workflow names at runtime rather than at CLI definition time.

Closes: #419