### PR TITLE
fix: make iteration instructions more explicit in pre-context

### DIFF
--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -174,7 +174,10 @@ const handlePreContextInjection = (
           colors.gray(`✓ Pre-context file location added to step ${step.id}\n`)
         );
 
-        step.prompt = preContextMessage + '\n\n**USE** pre-context information to identify the current iteration and **PRIORITIZE** its instructions (at `currentIteration` in the JSON), taking into account previous iterations instructions (at `previousIterations` in the JSON).\n\n---\n\n' + step.prompt;
+        step.prompt =
+          preContextMessage +
+          '\n\n**USE** pre-context information to identify the current iteration and **PRIORITIZE** its instructions (at `currentIteration` in the JSON), taking into account previous iterations instructions (at `previousIterations` in the JSON).\n\n---\n\n' +
+          step.prompt;
       }
     }
   }


### PR DESCRIPTION
Improves the clarity of pre-context iteration instructions injected into agent prompts. The previous wording was too subtle and agents sometimes missed the iteration context, leading to incomplete or incorrect task execution.

Closes: https://github.com/endorhq/rover/issues/444

## Changes

- Changed the pre-context label from "Note" to "Important" to draw more attention
- Added explicit description that JSON files contain "task and iterations instructions"
- Added clear directive to **USE** pre-context information and **PRIORITIZE** the `currentIteration` instructions
- Instructed agents to take into account `previousIterations` in the JSON for context continuity