### PR TITLE
fix: prevent onComplete hooks from firing multiple times

### DIFF
--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -714,6 +714,9 @@ export class TaskDescriptionManager {
   get source(): TaskDescription['source'] {
     return this.data.source;
   }
+  get onCompleteHookFiredForStatus(): TaskDescription['onCompleteHookFiredForStatus'] {
+    return this.data.onCompleteHookFiredForStatus;
+  }
 
   // ============================================================
   // Data Modification (Setters)
@@ -748,6 +751,15 @@ export class TaskDescriptionManager {
    */
   setBaseCommit(commit: string): void {
     this.data.baseCommit = commit;
+    this.save();
+  }
+
+  /**
+   * Record that the onComplete hook was fired for a specific status.
+   * Used to prevent duplicate hook executions across process restarts.
+   */
+  setOnCompleteHookFiredForStatus(status: TaskStatus): void {
+    this.data.onCompleteHookFiredForStatus = status;
     this.save();
   }
 

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -84,6 +84,10 @@ export const TaskDescriptionSchema = z.object({
   // Task source (origin tracking - github, manual, etc.)
   source: TaskSourceSchema.optional(),
 
+  // Hook tracking - stores the status when onComplete hook was last fired
+  // Prevents duplicate hook executions across process restarts
+  onCompleteHookFiredForStatus: TaskStatusSchema.optional(),
+
   // Metadata
   version: z.string(),
 });


### PR DESCRIPTION
## Summary

Fixes the `onComplete` hook firing multiple times instead of once per task completion. This was caused by two issues:

**1. No persistence across process restarts**

The `previousTaskStatuses` Map was module-level and started empty on every `rover list` invocation. This meant:
- First `rover list`: hooks fire for all completed/failed tasks
- Second `rover list`: hooks fire **again** for the same tasks (new process, empty map)

**2. Task ID collision in global mode**

The Map key was just `task.id`, but task IDs are only unique within a project. In global mode, Project A's task 1 and Project B's task 1 would share the same tracking entry, causing incorrect behavior.

## Solution

Replace the in-memory `previousTaskStatuses` Map with a persisted field `onCompleteHookFiredForStatus` stored in each task's `description.json` file. This ensures:
- Hooks only fire once per task completion, even across process restarts
- No key collisions since state is stored per-task
- Works correctly in both scoped and global mode, and in both watch and non-watch mode

## Changes

- Add `onCompleteHookFiredForStatus` field to task description schema
- Add getter/setter in `TaskDescriptionManager`
- Update `list.ts` to check persisted state instead of in-memory map

## Test plan

- [x] Build passes
- [x] All existing tests pass
- [ ] Manual test: Run `rover list` multiple times on a project with completed tasks - hook should only fire once

🤖 Generated with [Claude Code](https://claude.com/claude-code)