### PR TITLE
feat(task): add --include-comments flag for GitHub issue comments

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -100,6 +100,7 @@ const mcpCommand = async () => {
   const taskSchema = z.object({
     initPrompt: z.string(),
     fromGithub: z.string().optional(),
+    includeComments: z.boolean().optional(),
     sourceBranch: z.string().optional(),
     targetBranch: z.string().optional(),
     agent: z.nativeEnum(AI_AGENT).optional(),
@@ -116,6 +117,7 @@ const mcpCommand = async () => {
       const parsed = taskSchema.parse(args);
       return runCommand(taskCmd.action, [parsed.initPrompt], {
         fromGithub: parsed.fromGithub,
+        includeComments: parsed.includeComments,
         yes: true,
         sourceBranch: parsed.sourceBranch,
         targetBranch: parsed.targetBranch,

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -208,6 +208,7 @@ interface TaskTaskOutput extends CLIJsonOutput {
 interface TaskOptions {
   workflow?: string;
   fromGithub?: string;
+  includeComments?: boolean;
   yes?: boolean;
   sourceBranch?: string;
   targetBranch?: string;
@@ -218,6 +219,38 @@ interface TaskOptions {
   networkAllow?: string[];
   networkBlock?: string[];
 }
+
+/**
+ * Format a date string to a more readable format (YYYY-MM-DD)
+ */
+const formatCommentDate = (dateString: string): string => {
+  if (!dateString) return '';
+  try {
+    const date = new Date(dateString);
+    return date.toISOString().split('T')[0];
+  } catch {
+    return dateString;
+  }
+};
+
+/**
+ * Format GitHub comments as markdown to append to the issue body
+ */
+const formatCommentsAsMarkdown = (
+  comments: Array<{ author: string; body: string; createdAt: string }>
+): string => {
+  if (!comments || comments.length === 0) return '';
+
+  const formattedComments = comments
+    .map(comment => {
+      const date = formatCommentDate(comment.createdAt);
+      const dateStr = date ? ` (${date})` : '';
+      return `**@${comment.author}**${dateStr}:\n${comment.body}`;
+    })
+    .join('\n\n');
+
+  return `\n\n---\n## Comments\n\n${formattedComments}`;
+};
 
 /**
  * Build NetworkConfig from CLI options
@@ -477,7 +510,15 @@ const createTaskForAgent = async (
 const taskCommand = async (initPrompt?: string, options: TaskOptions = {}) => {
   const telemetry = getTelemetry();
   // Extract options
-  const { yes, json, fromGithub, sourceBranch, targetBranch, agent } = options;
+  const {
+    yes,
+    json,
+    fromGithub,
+    includeComments,
+    sourceBranch,
+    targetBranch,
+    agent,
+  } = options;
 
   // Set global JSON mode for tests and backwards compatibility
   if (json !== undefined) {
@@ -489,6 +530,21 @@ const taskCommand = async (initPrompt?: string, options: TaskOptions = {}) => {
   const jsonOutput: TaskTaskOutput = {
     success: false,
   };
+
+  // Validate --include-comments requires --from-github
+  if (includeComments && !fromGithub) {
+    jsonOutput.error =
+      '--include-comments requires --from-github to be specified';
+    await exitWithError(jsonOutput, {
+      tips: [
+        'Use ' +
+          colors.cyan('rover task --from-github <issue> --include-comments') +
+          ' to include issue comments',
+      ],
+      telemetry: getTelemetry(),
+    });
+    return;
+  }
 
   // Get project context
   let project;
@@ -685,9 +741,22 @@ const taskCommand = async (initPrompt?: string, options: TaskOptions = {}) => {
       }
 
       try {
-        const issueData = await github.fetchIssue(fromGithub, remoteUrl);
+        const issueData = await github.fetchIssue(fromGithub, remoteUrl, {
+          includeComments,
+        });
         if (issueData) {
+          // Start with the issue body
           description = issueData.body;
+
+          // Append comments if they were included
+          if (
+            includeComments &&
+            issueData.comments &&
+            issueData.comments.length > 0
+          ) {
+            description += formatCommentsAsMarkdown(issueData.comments);
+          }
+
           inputsData.set('description', description);
 
           if (!issueData.body || issueData.body.length == 0) {

--- a/packages/cli/src/lib/github.ts
+++ b/packages/cli/src/lib/github.ts
@@ -7,9 +7,20 @@ export class GitHubError extends Error {
   }
 }
 
+type GitHubComment = {
+  author: string;
+  body: string;
+  createdAt: string;
+};
+
 type GitHubIssueResult = {
   title: string;
   body: string;
+  comments?: GitHubComment[];
+};
+
+type FetchIssueOptions = {
+  includeComments?: boolean;
 };
 
 export type GitHubOptions = {
@@ -49,13 +60,20 @@ export class GitHub {
    * Fetch the GitHub issue title and body from the given issue number and
    * remote URL. It will try to use the gh CLI and the API as a fallback.
    *
+   * @param number - The issue number
+   * @param remoteUrl - The remote URL of the repository
+   * @param options - Optional configuration for fetching
+   * @param options.includeComments - Whether to include issue comments
    * @throws GitHubError
    */
   async fetchIssue(
     number: string | number,
-    remoteUrl: string
+    remoteUrl: string,
+    options: FetchIssueOptions = {}
   ): Promise<GitHubIssueResult> {
+    const { includeComments = false } = options;
     const repoInfo = this.getGitHubRepoInfo(remoteUrl);
+    const jsonFields = includeComments ? 'title,body,comments' : 'title,body';
 
     if (repoInfo) {
       // First, CLI. If it's not available, it will fail.
@@ -66,7 +84,7 @@ export class GitHub {
         '--repo',
         `${repoInfo.owner}/${repoInfo.repo}`,
         '--json',
-        'title,body',
+        jsonFields,
       ]);
 
       if (result.failed || result.stdout == null) {
@@ -87,10 +105,21 @@ export class GitHub {
           }
 
           const issue = await response.json();
-          return {
+          const issueResult: GitHubIssueResult = {
             title: issue.title || '',
             body: issue.body || '',
           };
+
+          // Fetch comments if requested
+          if (includeComments) {
+            issueResult.comments = await this.fetchIssueComments(
+              repoInfo.owner,
+              repoInfo.repo,
+              number
+            );
+          }
+
+          return issueResult;
         } catch (err) {
           if (err instanceof GitHubError) {
             throw err;
@@ -103,10 +132,17 @@ export class GitHub {
         // Return the data
         try {
           const issue = JSON.parse(result.stdout.toString());
-          return {
+          const issueResult: GitHubIssueResult = {
             title: issue.title,
             body: issue.body || '',
           };
+
+          // Parse comments from gh CLI response
+          if (includeComments && issue.comments) {
+            issueResult.comments = this.parseGhCliComments(issue.comments);
+          }
+
+          return issueResult;
         } catch (_err) {
           throw new GitHubError(
             'The GitHub CLI returned an invalid JSON response: ' + result.stdout
@@ -123,7 +159,7 @@ export class GitHub {
 
       const result = await launch(
         'gh',
-        ['issue', 'view', number.toString(), '--json', 'title,body'],
+        ['issue', 'view', number.toString(), '--json', jsonFields],
         { cwd: this.cwd }
       );
 
@@ -133,16 +169,80 @@ export class GitHub {
         // Return the data
         try {
           const issue = JSON.parse(result.stdout.toString());
-          return {
+          const issueResult: GitHubIssueResult = {
             title: issue.title,
             body: issue.body || '',
           };
+
+          // Parse comments from gh CLI response
+          if (includeComments && issue.comments) {
+            issueResult.comments = this.parseGhCliComments(issue.comments);
+          }
+
+          return issueResult;
         } catch (_err) {
           throw new GitHubError(
             'The GitHub CLI returned an invalid JSON response: ' + result.stdout
           );
         }
       }
+    }
+  }
+
+  /**
+   * Parse comments from gh CLI JSON response format
+   */
+  private parseGhCliComments(
+    comments: Array<{
+      author?: { login?: string };
+      body?: string;
+      createdAt?: string;
+    }>
+  ): GitHubComment[] {
+    return comments.map(comment => ({
+      author: comment.author?.login || 'unknown',
+      body: comment.body || '',
+      createdAt: comment.createdAt || '',
+    }));
+  }
+
+  /**
+   * Fetch comments for an issue using the GitHub API
+   */
+  private async fetchIssueComments(
+    owner: string,
+    repo: string,
+    issueNumber: string | number
+  ): Promise<GitHubComment[]> {
+    try {
+      const apiUrl = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`;
+      const response = await fetch(apiUrl, {
+        headers: {
+          'User-Agent': 'Rover-CLI',
+          Accept: 'application/vnd.github.v3+json',
+        },
+      });
+
+      if (!response.ok) {
+        // Non-fatal: return empty comments array if we can't fetch them
+        return [];
+      }
+
+      const comments = await response.json();
+      return comments.map(
+        (comment: {
+          user?: { login?: string };
+          body?: string;
+          created_at?: string;
+        }) => ({
+          author: comment.user?.login || 'unknown',
+          body: comment.body || '',
+          createdAt: comment.created_at || '',
+        })
+      );
+    } catch (_err) {
+      // Non-fatal: return empty comments array if we can't fetch them
+      return [];
     }
   }
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -243,6 +243,10 @@ export function createProgram(
       '--from-github <issue>',
       'Fetch task description from a GitHub issue number'
     )
+    .option(
+      '--include-comments',
+      'Include issue comments in the task description (requires --from-github)'
+    )
     .addOption(
       new Option(
         '--workflow, -w <name>',


### PR DESCRIPTION
## Summary

- Add a new `--include-comments` flag to the `rover task` command that works alongside `--from-github` to fetch and include issue comments in the task description
- When used, comments are appended to the issue body in a formatted markdown section
- Validates that `--include-comments` requires `--from-github` to be specified

## Changes

- **packages/cli/src/lib/github.ts**: Add `GitHubComment` type, update `GitHubIssueResult` to include optional comments, modify `fetchIssue()` to accept `includeComments` option, add helper methods for parsing comments
- **packages/cli/src/program.ts**: Add `--include-comments` flag with description
- **packages/cli/src/commands/task.ts**: Add validation, pass option to `fetchIssue()`, format and append comments to description
- **packages/cli/src/commands/mcp.ts**: Add `includeComments` to task schema

## Comment Format

When comments are included, they are appended as:
```markdown
[issue body]

---
## Comments

**@username** (2024-01-15):
Comment text here...
```

## Test plan

- [x] Build passes
- [x] All existing tests pass (335 tests)
- [x] Error case: `--include-comments` without `--from-github` shows proper error
- [x] Verified with real GitHub issue (#442) that has comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)