### PR TITLE
fix: allow push command to push already committed but unpushed changes

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -465,16 +465,15 @@ export class Git {
   ): boolean {
     const targetBranch = options.targetBranch || this.getCurrentBranch();
 
-    try {
-      const unmergedCommits =
-        launchSync('git', ['log', `${targetBranch}..${srcBranch}`, '--oneline'])
-          .stdout?.toString()
-          .trim() || '';
+    // Let errors propagate so callers can handle "remote doesn't exist" case
+    const unmergedCommits =
+      launchSync('git', ['log', `${targetBranch}..${srcBranch}`, '--oneline'], {
+        cwd: options.worktreePath ?? this.cwd,
+      })
+        .stdout?.toString()
+        .trim() || '';
 
-      return unmergedCommits.length > 0;
-    } catch (_err) {
-      return false;
-    }
+    return unmergedCommits.length > 0;
   }
 
   /**


### PR DESCRIPTION
Fixes a bug where `rover push` incorrectly exits with "No changes to push" when there are committed but unpushed changes on a task branch.

The root cause was in the `hasUnmergedCommits` function which caught all errors internally and returned `false`. This prevented the push command from distinguishing between "no unpushed commits" (should exit) and "remote branch doesn't exist" (should continue with push).

## Changes

- Remove try/catch block in `hasUnmergedCommits` to let errors propagate to callers
- Add `cwd` option to `launchSync` call to ensure the git command runs in the correct worktree directory

## Notes

The push command logic in `push.ts` was already correct - it has a try/catch expecting `hasUnmergedCommits` to throw when the remote branch doesn't exist. The fix simply allows errors to propagate as originally intended.