### PR TITLE
chore: add Ctrl-n and Ctrl-p navigation to interactive selectors

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -19,6 +19,7 @@ import {
   AI_AGENT,
 } from 'rover-core';
 import { showRoverChat, showTips, TIP_TITLES } from '../utils/display.js';
+import { selectPromptActions } from '../utils/prompt-actions.js';
 import { getTelemetry } from '../lib/telemetry.js';
 import { exitWithError, exitWithWarn, exitWithSuccess } from '../utils/exit.js';
 import type { CommandDefinition } from '../types.js';
@@ -272,7 +273,8 @@ const initCommand = async (path: string = '.', options: { yes?: boolean }) => {
             name: agent.charAt(0).toUpperCase() + agent.slice(1),
             value: agent,
           })),
-        })) as { aiAgent: string };
+          actions: selectPromptActions,
+        } as Parameters<typeof prompt>[0])) as { aiAgent: string };
 
         defaultAIAgent = result?.aiAgent.toLocaleLowerCase() as AI_AGENT;
       } catch (error) {

--- a/packages/cli/src/utils/project-selector.ts
+++ b/packages/cli/src/utils/project-selector.ts
@@ -5,6 +5,7 @@
 import colors from 'ansi-colors';
 import enquirer from 'enquirer';
 import { ProjectStore, type ProjectManager } from 'rover-core';
+import { selectPromptActions } from './prompt-actions.js';
 
 const { AutoComplete } = enquirer as unknown as {
   AutoComplete: new (options: {
@@ -12,6 +13,7 @@ const { AutoComplete } = enquirer as unknown as {
     message: string;
     limit: number;
     choices: Array<{ name: string; value: string }>;
+    actions: Record<string, Record<string, string>>;
   }) => {
     run(): Promise<string>;
   };
@@ -50,6 +52,7 @@ export async function promptProjectSelection(): Promise<ProjectManager | null> {
       message: 'Select a project',
       limit: 10,
       choices,
+      actions: selectPromptActions,
     });
 
     const selectedId = await prompt.run();

--- a/packages/cli/src/utils/prompt-actions.ts
+++ b/packages/cli/src/utils/prompt-actions.ts
@@ -1,0 +1,20 @@
+/**
+ * Custom Enquirer key actions that add Ctrl-n (down) and Ctrl-p (up) bindings
+ * to select-type prompts (Select, AutoComplete).
+ *
+ * Enquirer's keypress.action() does a shallow merge of the default combos
+ * with custom actions, so we must provide the full ctrl map when overriding.
+ * Only actions meaningful for select prompts are included.
+ */
+export const selectPromptActions = {
+  ctrl: {
+    a: 'first',
+    c: 'cancel',
+    e: 'last',
+    g: 'reset',
+    j: 'submit',
+    m: 'cancel',
+    n: 'down',
+    p: 'up',
+  },
+};


### PR DESCRIPTION
Add `Ctrl-n` (down) and `Ctrl-p` (up) keybindings to Enquirer select-type prompts, providing a familiar navigation experience for users accustomed to Emacs-style or terminal shortcuts.

## Changes

- Add `prompt-actions.ts` utility with a custom Enquirer `actions` map that includes `Ctrl-n` → `down` and `Ctrl-p` → `up` bindings alongside the full default ctrl combo set
- Apply the custom actions to the AI agent selector in the `init` command
- Apply the custom actions to the `AutoComplete` project selector in `project-selector.ts`