### PR TITLE
fix: support multiple GitHub accounts and fix error logging

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -33,8 +33,7 @@ const getGitHubRepoInfo = (
 ): { owner: string; repo: string } | null => {
   // Handle various GitHub URL formats
   const patterns = [
-    /github\.com[:/]([^/]+)\/([^/.]+)(\.git)?$/,
-    /^git@github\.com:([^/]+)\/([^/.]+)(\.git)?$/,
+    /github[^:/]*[:/]([^/]+)\/([^/.]+)(\.git)?$/,
     /^https?:\/\/github\.com\/([^/]+)\/([^/.]+)(\.git)?$/,
   ];
 

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -758,7 +758,7 @@ const taskCommand = async (initPrompt?: string, options: TaskOptions = {}) => {
         }
       } catch (err) {
         if (err instanceof GitHubError) {
-          jsonOutput.error = `Failed to fetch issue from GitHub: ${err.cause}`;
+          jsonOutput.error = `Failed to fetch issue from GitHub: ${err.message}`;
         } else {
           jsonOutput.error = `Failed to fetch issue from GitHub: ${err}`;
         }

--- a/packages/cli/src/lib/__tests__/github.test.ts
+++ b/packages/cli/src/lib/__tests__/github.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('rover-core', async () => {
+  const actual = await vi.importActual('rover-core');
+  return {
+    ...actual,
+    launch: vi.fn(),
+    launchSync: vi.fn(),
+  };
+});
+
+import { GitHub } from '../github.js';
+
+describe('getGitHubRepoInfo', () => {
+  const github = new GitHub();
+
+  it('parses standard SSH URL', () => {
+    expect(github.getGitHubRepoInfo('git@github.com:org/repo.git')).toEqual({
+      owner: 'org',
+      repo: 'repo',
+    });
+  });
+
+  it('parses standard SSH URL without .git suffix', () => {
+    expect(github.getGitHubRepoInfo('git@github.com:org/repo')).toEqual({
+      owner: 'org',
+      repo: 'repo',
+    });
+  });
+
+  it('parses standard HTTPS URL', () => {
+    expect(github.getGitHubRepoInfo('https://github.com/org/repo.git')).toEqual(
+      {
+        owner: 'org',
+        repo: 'repo',
+      }
+    );
+  });
+
+  it('parses HTTPS URL without .git suffix', () => {
+    expect(github.getGitHubRepoInfo('https://github.com/org/repo')).toEqual({
+      owner: 'org',
+      repo: 'repo',
+    });
+  });
+
+  it('parses SSH alias with underscore (github.com_work)', () => {
+    expect(
+      github.getGitHubRepoInfo('git@github.com_work:org/repo.git')
+    ).toEqual({
+      owner: 'org',
+      repo: 'repo',
+    });
+  });
+
+  it('parses SSH alias with dash (github-personal)', () => {
+    expect(
+      github.getGitHubRepoInfo('git@github-personal:org/repo.git')
+    ).toEqual({
+      owner: 'org',
+      repo: 'repo',
+    });
+  });
+
+  it('parses ssh:// protocol URL', () => {
+    expect(
+      github.getGitHubRepoInfo('ssh://git@github.com/org/repo.git')
+    ).toEqual({
+      owner: 'org',
+      repo: 'repo',
+    });
+  });
+
+  it('returns null for non-GitHub URL', () => {
+    expect(github.getGitHubRepoInfo('git@gitlab.com:org/repo.git')).toBeNull();
+  });
+
+  it('returns null for non-GitHub HTTPS URL', () => {
+    expect(
+      github.getGitHubRepoInfo('https://gitlab.com/org/repo.git')
+    ).toBeNull();
+  });
+});

--- a/packages/cli/src/lib/github.ts
+++ b/packages/cli/src/lib/github.ts
@@ -153,8 +153,7 @@ export class GitHub {
   getGitHubRepoInfo(remoteUrl: string): { owner: string; repo: string } | null {
     // Handle various GitHub URL formats
     const patterns = [
-      /github\.com[:/]([^/]+)\/([^/.]+)(\.git)?$/,
-      /^git@github\.com:([^/]+)\/([^/.]+)(\.git)?$/,
+      /github[^:/]*[:/]([^/]+)\/([^/.]+)(\.git)?$/,
       /^https?:\/\/github\.com\/([^/]+)\/([^/.]+)(\.git)?$/,
     ];
 


### PR DESCRIPTION
## Summary
- Broadened `getGitHubRepoInfo()` regex to support custom SSH aliases (e.g. `github.com_work`, `github-personal`) for multi-account setups
- Fixed `err.cause` → `err.message` in task.ts error handler (`GitHubError` never sets `cause`, producing `"undefined"`)
- Applied the same regex fix to the duplicate in `push.ts`
- Added tests for `getGitHubRepoInfo()` covering standard SSH/HTTPS, SSH aliases, and non-GitHub URLs

Closes #460

## Test plan
- [x] All existing tests pass (`pnpm test`)
- [x] New `github.test.ts` covers standard SSH, HTTPS, SSH aliases with underscore/dash, `ssh://` protocol, and non-GitHub URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)