### PR TITLE
fix: onComplete hook should fire on every terminal status transition

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -255,9 +255,9 @@ const listCommand = async (
         const isTerminalStatus =
           currentStatus === 'COMPLETED' || currentStatus === 'FAILED';
 
-        // Check if hook has already been fired for this status (persisted in task file)
+        // Check if hook has already been fired for this status transition
         const hookAlreadyFired =
-          task.onCompleteHookFiredForStatus === currentStatus;
+          task.onCompleteHookFiredAt === task.lastStatusCheck;
 
         // Load project config for hooks per project
         let projectConfig: ProjectConfigManager | undefined;
@@ -288,8 +288,8 @@ const listCommand = async (
             'onComplete'
           );
 
-          // Record that hook was fired for this status (persists to task file)
-          task.setOnCompleteHookFiredForStatus(currentStatus);
+          // Record that hook was fired for this status transition (persists to task file)
+          task.setOnCompleteHookFiredAt(task.lastStatusCheck!);
         }
       } catch (err) {
         if (!isJsonMode()) {

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -714,8 +714,8 @@ export class TaskDescriptionManager {
   get source(): TaskDescription['source'] {
     return this.data.source;
   }
-  get onCompleteHookFiredForStatus(): TaskDescription['onCompleteHookFiredForStatus'] {
-    return this.data.onCompleteHookFiredForStatus;
+  get onCompleteHookFiredAt(): TaskDescription['onCompleteHookFiredAt'] {
+    return this.data.onCompleteHookFiredAt;
   }
 
   // ============================================================
@@ -755,11 +755,11 @@ export class TaskDescriptionManager {
   }
 
   /**
-   * Record that the onComplete hook was fired for a specific status.
-   * Used to prevent duplicate hook executions across process restarts.
+   * Record that the onComplete hook was fired at a specific lastStatusCheck timestamp.
+   * Used to prevent duplicate hook executions while allowing re-fires after iterate/restart.
    */
-  setOnCompleteHookFiredForStatus(status: TaskStatus): void {
-    this.data.onCompleteHookFiredForStatus = status;
+  setOnCompleteHookFiredAt(timestamp: string): void {
+    this.data.onCompleteHookFiredAt = timestamp;
     this.save();
   }
 

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -84,9 +84,9 @@ export const TaskDescriptionSchema = z.object({
   // Task source (origin tracking - github, manual, etc.)
   source: TaskSourceSchema.optional(),
 
-  // Hook tracking - stores the status when onComplete hook was last fired
-  // Prevents duplicate hook executions across process restarts
-  onCompleteHookFiredForStatus: TaskStatusSchema.optional(),
+  // Hook tracking - stores the lastStatusCheck timestamp when onComplete hook was last fired
+  // Compared against lastStatusCheck to detect new terminal status transitions
+  onCompleteHookFiredAt: z.string().datetime().optional(),
 
   // Metadata
   version: z.string(),


### PR DESCRIPTION
## Summary

- Replaces `onCompleteHookFiredForStatus` (status string) with `onCompleteHookFiredAt` (timestamp) to track when the onComplete hook last fired
- Compares against `lastStatusCheck` to detect new terminal transitions, ensuring the hook re-fires after iterate or restart
- Fixes cases where COMPLETED→iterate→COMPLETED or FAILED→restart→FAILED would not re-trigger the hook

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (338 tests)
- [ ] Manual: complete a task, verify hook fires once, poll again — no duplicate
- [ ] Manual: iterate completed task, verify hook fires on second completion
- [ ] Manual: restart failed task, verify hook fires when it reaches terminal again

🤖 Generated with [Claude Code](https://claude.com/claude-code)