### PR TITLE
feat(iterate): add --include-comments flag for GitHub issue comments

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -279,6 +279,8 @@ const mcpCommand = async () => {
   const iterateSchema = z.object({
     taskId: z.string(),
     instructions: z.string().optional(),
+    fromGithub: z.string().optional(),
+    includeComments: z.boolean().optional(),
   });
 
   server.registerTool(
@@ -291,10 +293,14 @@ const mcpCommand = async () => {
     },
     async args => {
       const parsed = iterateSchema.parse(args);
-      return runCommand(iterateCmd.action, [
-        parsed.taskId,
-        parsed.instructions,
-      ]);
+      return runCommand(
+        iterateCmd.action,
+        [parsed.taskId, parsed.instructions],
+        {
+          fromGithub: parsed.fromGithub,
+          includeComments: parsed.includeComments,
+        }
+      );
     }
   );
 

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -32,7 +32,11 @@ import { NewTaskProvider } from 'rover-telemetry';
 import { readFromStdin, stdinIsAvailable } from '../utils/stdin.js';
 import type { CLIJsonOutput } from '../types.js';
 import { exitWithError, exitWithSuccess, exitWithWarn } from '../utils/exit.js';
-import { GitHub, GitHubError } from '../lib/github.js';
+import {
+  GitHub,
+  GitHubError,
+  formatCommentsAsMarkdown,
+} from '../lib/github.js';
 import { copyEnvironmentFiles } from '../utils/env-files.js';
 import { initWorkflowStore } from '../lib/workflow.js';
 import {
@@ -219,38 +223,6 @@ interface TaskOptions {
   networkAllow?: string[];
   networkBlock?: string[];
 }
-
-/**
- * Format a date string to a more readable format (YYYY-MM-DD)
- */
-const formatCommentDate = (dateString: string): string => {
-  if (!dateString) return '';
-  try {
-    const date = new Date(dateString);
-    return date.toISOString().split('T')[0];
-  } catch {
-    return dateString;
-  }
-};
-
-/**
- * Format GitHub comments as markdown to append to the issue body
- */
-const formatCommentsAsMarkdown = (
-  comments: Array<{ author: string; body: string; createdAt: string }>
-): string => {
-  if (!comments || comments.length === 0) return '';
-
-  const formattedComments = comments
-    .map(comment => {
-      const date = formatCommentDate(comment.createdAt);
-      const dateStr = date ? ` (${date})` : '';
-      return `**@${comment.author}**${dateStr}:\n${comment.body}`;
-    })
-    .join('\n\n');
-
-  return `\n\n---\n## Comments\n\n${formattedComments}`;
-};
 
 /**
  * Build NetworkConfig from CLI options

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -382,6 +382,14 @@ export function createProgram(
       'Open an interactive command session to iterate on the task'
     )
     .option('--json', 'Output JSON and skip confirmation prompts')
+    .option(
+      '--from-github <issue>',
+      'GitHub issue number to fetch comments from'
+    )
+    .option(
+      '--include-comments',
+      'Include new GitHub issue comments in iteration instructions'
+    )
     .action(iterateCmd.action);
 
   program

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -718,6 +718,14 @@ export class TaskDescriptionManager {
     return this.data.onCompleteHookFiredForStatus;
   }
 
+  /**
+   * Update task source metadata
+   */
+  updateSource(source: TaskDescription['source']): void {
+    this.data.source = source;
+    this.save();
+  }
+
   // ============================================================
   // Data Modification (Setters)
   // ============================================================

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -29,6 +29,7 @@ export const TaskSourceSchema = z.object({
   url: z.string().url().optional(),
   title: z.string().optional(),
   ref: z.record(z.string(), z.unknown()).optional(),
+  lastCommentFetchedAt: z.string().datetime().optional(),
 });
 
 // Task description schema

--- a/packages/schemas/src/task-description/types.ts
+++ b/packages/schemas/src/task-description/types.ts
@@ -22,6 +22,7 @@ export interface TaskSource {
   url?: string; // Human-readable URL for the source
   title?: string; // Human-readable title/context
   ref?: Record<string, unknown>; // Source-specific data for API calls
+  lastCommentFetchedAt?: string; // Timestamp of last comment fetch for incremental filtering
 }
 
 // Data required to create a new task


### PR DESCRIPTION
> **Stack:** This PR is stacked on #454. Review only the second commit.

## Summary

Adds `--include-comments` and `--from-github <issue>` flags to `rover iterate`, enabling a feedback loop between GitHub issues and rover tasks.

### Why this is useful

When working with rover tasks created from GitHub issues, the conversation often continues on the issue after the task is started. Reviewers leave feedback, requirements get clarified, or the scope changes — all as issue comments. Without this feature, you'd have to manually copy-paste those comments into iteration instructions.

With `--include-comments`, you can:

- **Iterate from issue feedback**: A reviewer comments on the GitHub issue with change requests. Run `rover iterate <id> --include-comments` and those comments become the iteration instructions automatically.
- **Combine your own instructions with issue comments**: Run `rover iterate <id> "also fix the tests" --include-comments` to give your own direction while also pulling in any new comments from the issue.
- **Point an existing task at a different issue**: Use `--from-github <issue>` to pull comments from any issue, even if the task wasn't originally created from one. Useful when the discussion moves to a different issue or you want to incorporate feedback from a related issue.
- **Only get what's new**: After the first fetch, `lastCommentFetchedAt` is stored in the task metadata. Subsequent `--include-comments` calls only pull comments posted since the last fetch, so you don't re-process old feedback.

### Changes

- Add `--include-comments` and `--from-github <issue>` flags to `rover iterate` and MCP iterate schema
- Add `lastCommentFetchedAt` field to `TaskSource` schema for incremental comment filtering
- Add `since` parameter to GitHub comment fetching (REST API query param + client-side filtering for gh CLI)
- Add `updateSource()` method to `TaskDescriptionManager`
- Extract `formatCommentsAsMarkdown` and `formatCommentDate` from `task.ts` into `github.ts` as shared exports

## Test plan

- [x] `pnpm build` passes with no type errors
- [x] `pnpm test` — all 335 tests pass
- [x] `rover iterate --help` shows new flags
- [x] `--include-comments` without GitHub source shows clear error
- [x] `--include-comments --from-github 1` fetches and appends comments
- [x] Subsequent run shows "No new comments found" (incremental filtering works)
- [x] `lastCommentFetchedAt` and `id` persisted in task source metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)