### PR TITLE
feat: add -a/--agent flag to iterate command

### DIFF
--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -378,6 +378,10 @@ export function createProgram(
       'Open an interactive command session to iterate on the task'
     )
     .option('--json', 'Output JSON and skip confirmation prompts')
+    .option(
+      '-a, --agent <agent>',
+      'AI agent to use for this iteration (e.g., claude, claude:sonnet)'
+    )
     .action(iterateCmd.action);
 
   program

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -741,6 +741,12 @@ export class TaskDescriptionManager {
   /**
    * Set agent image
    */
+  setAgent(agent: string, model?: string): void {
+    this.data.agent = agent;
+    this.data.agentModel = model;
+    this.save();
+  }
+
   setAgentImage(agentImage: string): void {
     this.data.agentImage = agentImage;
     this.save();


### PR DESCRIPTION
## Summary

- Adds `-a, --agent <agent>` flag to `rover iterate`, supporting the same `agent:model` colon syntax as the `task` command (e.g., `-a claude:sonnet`)
- When iterating on a task you often want to switch to a different or more capable model — for example, using a stronger model to fix issues a smaller one couldn't resolve, or switching to a faster model for a straightforward follow-up
- The override is persisted to the task description so the sandbox picks up the new agent/model

### Without the flag (unchanged behavior)
```
rover iterate 3 "fix the bug"
# uses task's original agent → user settings → claude default
```

### With the flag
```
rover iterate 3 "fix the bug" -a claude:sonnet
# overrides to claude:sonnet for this and subsequent iterations
```

## Changes
- `packages/cli/src/program.ts` — register `-a, --agent` option on the iterate command
- `packages/cli/src/commands/iterate.ts` — parse the flag with `parseAgentString`, resolve default model, persist override via `task.setAgent()`
- `packages/core/src/files/task-description.ts` — add `setAgent()` method to `TaskDescriptionManager`

## Test plan
- [x] `pnpm build` compiles cleanly
- [x] All 338 existing unit tests pass
- [x] Manual: `rover iterate <id> "instructions" -a claude:sonnet` uses the specified agent/model
- [x] Manual: `rover iterate <id> "instructions"` (no flag) preserves existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)