### PR TITLE
feat: show agent:model in rover inspect output

### DIFF
--- a/packages/cli/src/commands/__tests__/inspect.test.ts
+++ b/packages/cli/src/commands/__tests__/inspect.test.ts
@@ -267,6 +267,79 @@ describe('inspect command', () => {
     });
   });
 
+  describe('Agent display', () => {
+    it('should show agent:model in human-readable output', async () => {
+      const { task } = createTestTask(1, 'Agent Task');
+      task.setAgent('claude', 'opus');
+
+      await inspectCommand('1');
+
+      const output = capturedOutput.join('\n');
+      expect(output).toContain('claude:opus');
+    });
+
+    it('should show agent without model in human-readable output', async () => {
+      const { task } = createTestTask(1, 'Agent Task');
+      task.setAgent('gemini');
+
+      await inspectCommand('1');
+
+      const output = capturedOutput.join('\n');
+      expect(output).toContain('gemini');
+    });
+
+    it('should show dash when no agent is set in human-readable output', async () => {
+      createTestTask(1, 'No Agent Task');
+
+      await inspectCommand('1');
+
+      const output = capturedOutput.join('\n');
+      // The Agent row should show '-'
+      expect(output).toMatch(/Agent.*-/);
+    });
+
+    it('should include agent fields in JSON output', async () => {
+      const { task } = createTestTask(1, 'Agent JSON Task');
+      task.setAgent('claude', 'opus');
+
+      await inspectCommand('1', undefined, { json: true });
+
+      const jsonOutput = capturedOutput.find(line => {
+        try {
+          JSON.parse(line);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      const parsed = JSON.parse(jsonOutput!);
+      expect(parsed.agent).toBe('claude');
+      expect(parsed.agentModel).toBe('opus');
+      expect(parsed.agentDisplay).toBe('claude:opus');
+    });
+
+    it('should have undefined agent fields in JSON when no agent set', async () => {
+      createTestTask(1, 'No Agent JSON Task');
+
+      await inspectCommand('1', undefined, { json: true });
+
+      const jsonOutput = capturedOutput.find(line => {
+        try {
+          JSON.parse(line);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      const parsed = JSON.parse(jsonOutput!);
+      expect(parsed.agent).toBeUndefined();
+      expect(parsed.agentModel).toBeUndefined();
+      expect(parsed.agentDisplay).toBeUndefined();
+    });
+  });
+
   describe('Standard output', () => {
     it('should display task details in human-readable format', async () => {
       createTestTask(1, 'Human Readable Task');

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -11,6 +11,7 @@ import {
   type TaskDescriptionManager,
 } from 'rover-core';
 import { TaskNotFoundError, type TaskStatus } from 'rover-schemas';
+import { formatAgentWithModel } from '../utils/agent-parser.js';
 import { join } from 'node:path';
 import { getTelemetry } from '../lib/telemetry.js';
 import {
@@ -89,6 +90,12 @@ interface TaskInspectionOutput {
   workflowName: string;
   /** Path to the git worktree for this task */
   worktreePath: string;
+  /** AI agent used for this task */
+  agent?: string;
+  /** Model used by the AI agent */
+  agentModel?: string;
+  /** Combined agent:model display string */
+  agentDisplay?: string;
   /** Task source (origin tracking - github, manual, etc.) */
   source?: {
     type: 'github' | 'manual';
@@ -315,6 +322,11 @@ const inspectCommand = async (
       // Output JSON format
       const jsonOutput: TaskInspectionOutput = {
         success: true,
+        agent: task.agent,
+        agentModel: task.agentModel,
+        agentDisplay: task.agent
+          ? formatAgentWithModel(task.agent as any, task.agentModel)
+          : undefined,
         baseCommit: task.baseCommit,
         branchName: task.branchName,
         completedAt: task.completedAt,
@@ -357,6 +369,9 @@ const inspectCommand = async (
         ID: `${task.id.toString()} (${colors.gray(task.uuid)})`,
         Title: task.title,
         Status: statusColorFunc(formattedStatus),
+        Agent: task.agent
+          ? formatAgentWithModel(task.agent as any, task.agentModel)
+          : '-',
         Workflow: task.workflowName,
         'Created At': new Date(task.createdAt).toLocaleString(),
       };


### PR DESCRIPTION
## Summary
- Adds an **Agent** row to the human-readable `rover inspect` Details section, displaying `agent:model` format (e.g., `claude:haiku`) or `-` if no agent is set
- Adds `agent`, `agentModel`, and `agentDisplay` fields to the JSON output (`--json` flag)
- Includes 5 new tests covering both human-readable and JSON output modes

## Test plan
- [x] Unit tests pass (`pnpm --filter @endorhq/rover test` — all 343 tests pass)
- [x] Manual testing: created a task with `--agent claude:haiku`, verified `rover inspect` shows `Agent: claude:haiku` in Details
- [x] Manual testing: verified `rover inspect --json` includes `agent`, `agentModel`, `agentDisplay` fields
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)