### PR TITLE
feat: add sandboxMetadata to store DOCKER_HOST for remote sandbox execution

### DIFF
--- a/packages/cli/src/commands/iterate.ts
+++ b/packages/cli/src/commands/iterate.ts
@@ -414,7 +414,13 @@ const iterateCommand = async (
       const containerId = await sandbox.createAndStart();
 
       // Update task metadata with new container ID for this iteration
-      task.setContainerInfo(containerId, 'running');
+      task.setContainerInfo(
+        containerId,
+        'running',
+        process.env.DOCKER_HOST
+          ? { dockerHost: process.env.DOCKER_HOST }
+          : undefined
+      );
 
       result.success = true;
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -215,7 +215,13 @@ const restartCommand = async (
       const containerId = await sandbox.createAndStart();
 
       // Update task metadata with new container ID
-      task.setContainerInfo(containerId, 'running');
+      task.setContainerInfo(
+        containerId,
+        'running',
+        process.env.DOCKER_HOST
+          ? { dockerHost: process.env.DOCKER_HOST }
+          : undefined
+      );
     } catch (error) {
       // If sandbox execution fails, reset task back to NEW status
       task.resetToNew();

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -94,7 +94,9 @@ const stopCommand = async (
 
     // Stop sandbox container if it exists and is running
     if (task.containerId) {
-      const sandbox = await createSandbox(task, processManager);
+      const sandbox = await createSandbox(task, processManager, {
+        sandboxMetadata: task.sandboxMetadata,
+      });
       await sandbox.stopAndRemove();
     }
 

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -159,7 +159,11 @@ const updateTaskMetadata = (
 
       // Handle Docker execution metadata
       if (updates.containerId && updates.executionStatus) {
-        task.setContainerInfo(updates.containerId, updates.executionStatus);
+        task.setContainerInfo(
+          updates.containerId,
+          updates.executionStatus,
+          updates.sandboxMetadata
+        );
       } else if (updates.executionStatus) {
         task.updateExecutionStatus(updates.executionStatus, {
           exitCode: updates.exitCode,
@@ -441,6 +445,9 @@ const createTaskForAgent = async (
         containerId,
         executionStatus: 'running',
         runningAt: new Date().toISOString(),
+        sandboxMetadata: process.env.DOCKER_HOST
+          ? { dockerHost: process.env.DOCKER_HOST }
+          : undefined,
       },
       jsonMode
     );

--- a/packages/cli/src/lib/sandbox/index.ts
+++ b/packages/cli/src/lib/sandbox/index.ts
@@ -35,6 +35,8 @@ export interface CreateSandboxOptions {
   extraArgs?: string;
   /** Explicit project path for configuration loading */
   projectPath?: string;
+  /** Sandbox-specific metadata (from task metadata) */
+  sandboxMetadata?: Record<string, unknown>;
 }
 
 /**

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -15,6 +15,8 @@ export interface SandboxOptions {
   extraArgs?: string;
   /** Project root path for loading configuration */
   projectPath?: string;
+  /** Sandbox-specific metadata (from task metadata) */
+  sandboxMetadata?: Record<string, unknown>;
 }
 
 export abstract class SandboxPackage {

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -196,6 +196,14 @@ export class TaskDescriptionManager {
 
     // Preserve all execution-related fields
     migrated.containerId = data.containerId || '';
+    // Migrate old dockerHost to sandboxMetadata
+    if (data.dockerHost !== undefined) {
+      migrated.sandboxMetadata = { dockerHost: data.dockerHost };
+      // Remove the old dockerHost field after migration
+      delete migrated.dockerHost;
+    } else {
+      migrated.sandboxMetadata = data.sandboxMetadata;
+    }
     migrated.executionStatus = data.executionStatus || '';
     migrated.runningAt = data.runningAt || undefined;
     migrated.errorAt = data.errorAt || undefined;
@@ -669,6 +677,9 @@ export class TaskDescriptionManager {
   get containerId(): string | undefined {
     return this.data.containerId;
   }
+  get sandboxMetadata(): Record<string, unknown> | undefined {
+    return this.data.sandboxMetadata;
+  }
   get executionStatus(): string | undefined {
     return this.data.executionStatus;
   }
@@ -776,9 +787,14 @@ export class TaskDescriptionManager {
   /**
    * Set container execution information
    */
-  setContainerInfo(containerId: string, executionStatus: string): void {
+  setContainerInfo(
+    containerId: string,
+    executionStatus: string,
+    sandboxMetadata?: Record<string, unknown>
+  ): void {
     this.data.containerId = containerId;
     this.data.executionStatus = executionStatus;
+    this.data.sandboxMetadata = sandboxMetadata;
     if (executionStatus === 'running') {
       this.data.runningAt = new Date().toISOString();
     }

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { NetworkConfigSchema } from '../project-config/schema.js';
 
 // Schema version for migrations
-export const CURRENT_TASK_DESCRIPTION_SCHEMA_VERSION = '1.3';
+export const CURRENT_TASK_DESCRIPTION_SCHEMA_VERSION = '1.5';
 
 // Task status schema
 export const TaskStatusSchema = z.enum([
@@ -61,8 +61,9 @@ export const TaskDescriptionSchema = z.object({
   sourceBranch: z.string().optional(),
   baseCommit: z.string().optional(),
 
-  // Docker Execution
+  // Sandbox Execution
   containerId: z.string().optional(),
+  sandboxMetadata: z.record(z.string(), z.unknown()).optional(),
   executionStatus: z.string().optional(),
   runningAt: z.string().datetime().optional(),
   errorAt: z.string().datetime().optional(),


### PR DESCRIPTION
Adds a `sandboxMetadata` field to the task description schema that allows sandbox backends to store arbitrary metadata. The primary use case is storing the `DOCKER_HOST` environment variable when tasks are executed on remote Docker hosts, ensuring that subsequent operations (logs, stop, restart) correctly target the same Docker daemon.

## Changes

- Added `sandboxMetadata` field to task description schema (version bump to 1.5)
- Store `DOCKER_HOST` in `sandboxMetadata` when creating tasks via `task`, `iterate`, and `restart` commands
- Pass stored `DOCKER_HOST` to Docker commands in `logs`, `stop`, and `DockerSandbox` operations
- Added migration logic to convert legacy `dockerHost` field to `sandboxMetadata`
- Updated tests to verify `sandboxMetadata` is correctly passed through all Docker operations
- Fixed release workflow to use correct image name `rover-agent` instead of `rover/agent`

## Notes

The `sandboxMetadata` field is designed to be extensible - it can store any key-value pairs that sandbox backends need to persist. Currently only `dockerHost` is used, but the structure allows for future expansion without schema changes.