### PR TITLE
chore: do not detach from terminal in interactive shells

### DIFF
--- a/packages/cli/src/commands/shell.ts
+++ b/packages/cli/src/commands/shell.ts
@@ -179,10 +179,14 @@ const shellCommand = async (
       }
 
       try {
+        // Use detached: false for interactive shells to ensure proper TTY
+        // signal handling and job control. Without this, the terminal can
+        // get into a corrupted state when using job control (Ctrl+Z, fg, etc.)
         const shellInit = launch(shell, shellArgs, {
           stdio: 'inherit',
           cwd: task.worktreePath,
           reject: false,
+          detached: false,
         });
 
         spinner.success(`Shell started using ${shell}`);

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -390,7 +390,12 @@ export class DockerSandbox extends Sandbox {
       dockerArgs.push('--pre-context-file', `/__pre_context_${index}__.json`);
     });
 
-    return launch('docker', dockerArgs, { stdio: 'inherit', reject: false });
+    // Use detached: false to ensure proper TTY signal handling and job control
+    return launch('docker', dockerArgs, {
+      stdio: 'inherit',
+      reject: false,
+      detached: false,
+    });
   }
 
   protected async remove(): Promise<string> {
@@ -461,9 +466,11 @@ export class DockerSandbox extends Sandbox {
     ];
 
     // Start Docker container with direct stdio inheritance for true interactivity
+    // Use detached: false to ensure proper TTY signal handling and job control
     await launch('docker', dockerArgs, {
       reject: false,
       stdio: 'inherit', // This gives full control to the user
+      detached: false,
     });
   }
 }

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -355,7 +355,12 @@ export class PodmanSandbox extends Sandbox {
       podmanArgs.push('--pre-context-file', `/__pre_context_${index}__.json`);
     });
 
-    return launch('podman', podmanArgs, { stdio: 'inherit', reject: false });
+    // Use detached: false to ensure proper TTY signal handling and job control
+    return launch('podman', podmanArgs, {
+      stdio: 'inherit',
+      reject: false,
+      detached: false,
+    });
   }
 
   protected async remove(): Promise<string> {
@@ -433,9 +438,11 @@ export class PodmanSandbox extends Sandbox {
     ];
 
     // Start Podman container with direct stdio inheritance for true interactivity
+    // Use detached: false to ensure proper TTY signal handling and job control
     await launch('podman', podmanArgs, {
       reject: false,
       stdio: 'inherit', // This gives full control to the user
+      detached: false,
     });
   }
 }

--- a/packages/core/src/os.ts
+++ b/packages/core/src/os.ts
@@ -16,6 +16,15 @@ export type { Options, Result, SyncOptions, SyncResult };
 // Expand some types to add our custom options
 export type LaunchOptions = Options & {
   mightLogSensitiveInformation?: boolean;
+  /**
+   * Whether to run the child process in a new process group (detached mode).
+   * Defaults to true to prevent child processes from being terminated when
+   * signals are sent to the parent's process group.
+   *
+   * Set to false for interactive processes (like shells) that need proper
+   * TTY signal handling and job control.
+   */
+  detached?: boolean;
 };
 
 export type LaunchSyncOptions = SyncOptions & {
@@ -165,8 +174,10 @@ export function launch(
     // Run in a new process group to prevent child processes from being
     // terminated when signals are sent to the parent's process group.
     // See: https://github.com/endorhq/rover/issues/374
+    // Default to detached: true unless explicitly set to false (e.g., for interactive shells)
+    const shouldDetach = options?.detached !== false;
     let newOpts: Options = {
-      detached: true,
+      detached: shouldDetach,
       ...expandedOptions,
     } as Options;
 
@@ -221,10 +232,15 @@ export function launch(
   // Run in a new process group to prevent child processes from being
   // terminated when signals are sent to the parent's process group.
   // See: https://github.com/endorhq/rover/issues/374
+  // Default to detached: true unless explicitly set to false (e.g., for interactive shells)
+  const shouldDetach = options?.detached !== false;
   if (expandedOptions) {
-    return execa({ detached: true, ...expandedOptions })`${parsedCommand}`;
+    return execa({
+      detached: shouldDetach,
+      ...expandedOptions,
+    })`${parsedCommand}`;
   } else {
-    return execa({ detached: true })`${parsedCommand}`;
+    return execa({ detached: shouldDetach })`${parsedCommand}`;
   }
 }
 


### PR DESCRIPTION
Fixes terminal state corruption issues when using job control (Ctrl+Z, `fg`, etc.) in interactive shells and container sessions. Previously, all child processes were launched in detached mode, which prevented proper TTY signal handling.

## Changes

- Added `detached` option to `LaunchOptions` in the core package, defaulting to `true` for backward compatibility
- Set `detached: false` for interactive shell sessions in the `shell` command
- Set `detached: false` for Docker and Podman interactive container launches

## Notes

The default behavior (`detached: true`) is preserved for non-interactive processes to maintain the fix for issue #374, where child processes were being terminated when signals were sent to the parent's process group. Interactive processes now explicitly opt out of detached mode to ensure proper TTY handling.