### PR TITLE
feat(core): add context provider abstraction and URI parser

### DIFF
--- a/packages/core/src/context/__tests__/errors.test.ts
+++ b/packages/core/src/context/__tests__/errors.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ContextError,
+  ContextSchemeNotSupportedError,
+  ContextUriParseError,
+  ContextTypeNotSupportedError,
+  ContextFetchError,
+} from '../errors.js';
+
+describe('Context Errors', () => {
+  describe('ContextError', () => {
+    it('should have correct name property', () => {
+      const error = new ContextError('test message');
+
+      expect(error.name).toBe('ContextError');
+    });
+
+    it('should include message', () => {
+      const error = new ContextError('test message');
+
+      expect(error.message).toBe('test message');
+    });
+
+    it('should be instanceof Error', () => {
+      const error = new ContextError('test');
+
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('ContextSchemeNotSupportedError', () => {
+    it('should have correct name property', () => {
+      const error = new ContextSchemeNotSupportedError('unknown');
+
+      expect(error.name).toBe('ContextSchemeNotSupportedError');
+    });
+
+    it('should include scheme in message', () => {
+      const error = new ContextSchemeNotSupportedError('foobar');
+
+      expect(error.message).toContain('foobar');
+      expect(error.message).toBe('Unsupported context scheme: "foobar"');
+    });
+
+    it('should store scheme property', () => {
+      const error = new ContextSchemeNotSupportedError('myscheme');
+
+      expect(error.scheme).toBe('myscheme');
+    });
+
+    it('should be instanceof ContextError', () => {
+      const error = new ContextSchemeNotSupportedError('test');
+
+      expect(error).toBeInstanceOf(ContextError);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('ContextUriParseError', () => {
+    it('should have correct name property', () => {
+      const error = new ContextUriParseError('bad://uri', 'invalid format');
+
+      expect(error.name).toBe('ContextUriParseError');
+    });
+
+    it('should include uri and reason in message', () => {
+      const error = new ContextUriParseError('broken://uri', 'missing host');
+
+      expect(error.message).toContain('broken://uri');
+      expect(error.message).toContain('missing host');
+      expect(error.message).toBe(
+        'Invalid context URI "broken://uri": missing host'
+      );
+    });
+
+    it('should store uri property', () => {
+      const error = new ContextUriParseError('test://uri', 'reason');
+
+      expect(error.uri).toBe('test://uri');
+    });
+
+    it('should be instanceof ContextError', () => {
+      const error = new ContextUriParseError('uri', 'reason');
+
+      expect(error).toBeInstanceOf(ContextError);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('ContextTypeNotSupportedError', () => {
+    it('should have correct name property', () => {
+      const error = new ContextTypeNotSupportedError('github', 'discussion', [
+        'issue',
+        'pr',
+      ]);
+
+      expect(error.name).toBe('ContextTypeNotSupportedError');
+    });
+
+    it('should include scheme, type, and supported types in message', () => {
+      const error = new ContextTypeNotSupportedError('github', 'release', [
+        'issue',
+        'pr',
+        'discussion',
+      ]);
+
+      expect(error.message).toContain('github');
+      expect(error.message).toContain('release');
+      expect(error.message).toContain('issue, pr, discussion');
+      expect(error.message).toBe(
+        'Provider "github" does not support type "release". ' +
+          'Supported types: issue, pr, discussion'
+      );
+    });
+
+    it('should store scheme, type, and supportedTypes properties', () => {
+      const error = new ContextTypeNotSupportedError('file', 'directory', [
+        'absolute',
+        'relative',
+      ]);
+
+      expect(error.scheme).toBe('file');
+      expect(error.type).toBe('directory');
+      expect(error.supportedTypes).toEqual(['absolute', 'relative']);
+    });
+
+    it('should be instanceof ContextError', () => {
+      const error = new ContextTypeNotSupportedError('s', 't', []);
+
+      expect(error).toBeInstanceOf(ContextError);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('ContextFetchError', () => {
+    it('should have correct name property', () => {
+      const error = new ContextFetchError(
+        'github:issue/123',
+        'network timeout'
+      );
+
+      expect(error.name).toBe('ContextFetchError');
+    });
+
+    it('should include uri and reason in message', () => {
+      const error = new ContextFetchError(
+        'file:./missing.md',
+        'file not found'
+      );
+
+      expect(error.message).toContain('file:./missing.md');
+      expect(error.message).toContain('file not found');
+      expect(error.message).toBe(
+        'Failed to fetch context from "file:./missing.md": file not found'
+      );
+    });
+
+    it('should store uri and reason properties', () => {
+      const error = new ContextFetchError('test://uri', 'some reason');
+
+      expect(error.uri).toBe('test://uri');
+      expect(error.reason).toBe('some reason');
+    });
+
+    it('should be instanceof ContextError', () => {
+      const error = new ContextFetchError('uri', 'reason');
+
+      expect(error).toBeInstanceOf(ContextError);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('Error inheritance chain', () => {
+    it('all context errors should be instanceof ContextError', () => {
+      const errors = [
+        new ContextError('base'),
+        new ContextSchemeNotSupportedError('scheme'),
+        new ContextUriParseError('uri', 'reason'),
+        new ContextTypeNotSupportedError('scheme', 'type', []),
+        new ContextFetchError('uri', 'reason'),
+      ];
+
+      for (const error of errors) {
+        expect(error).toBeInstanceOf(ContextError);
+        expect(error).toBeInstanceOf(Error);
+      }
+    });
+  });
+});

--- a/packages/core/src/context/__tests__/registry.test.ts
+++ b/packages/core/src/context/__tests__/registry.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+  ContextProvider,
+  ProviderOptions,
+  ContextEntry,
+} from '../types.js';
+import {
+  registerContextProvider,
+  createContextProvider,
+  isContextSchemeSupported,
+  getRegisteredSchemes,
+  clearContextProviders,
+} from '../registry.js';
+import {
+  ContextSchemeNotSupportedError,
+  ContextUriParseError,
+} from '../errors.js';
+
+// Test provider implementation
+class TestProvider implements ContextProvider {
+  readonly scheme = 'test';
+  readonly supportedTypes = ['type1', 'type2'];
+  readonly uri: string;
+  readonly url: URL;
+  readonly options: ProviderOptions;
+
+  constructor(url: URL, options: ProviderOptions = {}) {
+    this.url = url;
+    this.uri = url.href;
+    this.options = options;
+  }
+
+  async build(): Promise<ContextEntry[]> {
+    return [];
+  }
+}
+
+// Another test provider
+class AnotherProvider implements ContextProvider {
+  readonly scheme = 'another';
+  readonly supportedTypes = ['type3'];
+  readonly uri: string;
+
+  constructor(url: URL, _options?: ProviderOptions) {
+    this.uri = url.href;
+  }
+
+  async build(): Promise<ContextEntry[]> {
+    return [];
+  }
+}
+
+describe('Context Registry', () => {
+  beforeEach(() => {
+    clearContextProviders();
+  });
+
+  afterEach(() => {
+    clearContextProviders();
+  });
+
+  describe('registerContextProvider', () => {
+    it('should add provider to registry', () => {
+      registerContextProvider('test', TestProvider);
+
+      expect(isContextSchemeSupported('test')).toBe(true);
+    });
+
+    it('should allow registering multiple providers', () => {
+      registerContextProvider('test', TestProvider);
+      registerContextProvider('another', AnotherProvider);
+
+      expect(isContextSchemeSupported('test')).toBe(true);
+      expect(isContextSchemeSupported('another')).toBe(true);
+    });
+
+    it('should overwrite existing provider for same scheme', () => {
+      registerContextProvider('test', TestProvider);
+      registerContextProvider('test', AnotherProvider);
+
+      const provider = createContextProvider('test://resource');
+      expect(provider.scheme).toBe('another');
+    });
+  });
+
+  describe('isContextSchemeSupported', () => {
+    it('should return true for registered schemes', () => {
+      registerContextProvider('test', TestProvider);
+
+      expect(isContextSchemeSupported('test')).toBe(true);
+    });
+
+    it('should return false for unregistered schemes', () => {
+      expect(isContextSchemeSupported('unknown')).toBe(false);
+    });
+
+    it('should return false after clearing providers', () => {
+      registerContextProvider('test', TestProvider);
+      clearContextProviders();
+
+      expect(isContextSchemeSupported('test')).toBe(false);
+    });
+  });
+
+  describe('getRegisteredSchemes', () => {
+    it('should return empty array when no providers registered', () => {
+      expect(getRegisteredSchemes()).toEqual([]);
+    });
+
+    it('should return all registered schemes', () => {
+      registerContextProvider('test', TestProvider);
+      registerContextProvider('another', AnotherProvider);
+
+      const schemes = getRegisteredSchemes();
+      expect(schemes).toHaveLength(2);
+      expect(schemes).toContain('test');
+      expect(schemes).toContain('another');
+    });
+  });
+
+  describe('createContextProvider', () => {
+    beforeEach(() => {
+      registerContextProvider('test', TestProvider);
+    });
+
+    it('should return provider instance for valid URI', () => {
+      const provider = createContextProvider('test://resource/path');
+
+      expect(provider).toBeInstanceOf(TestProvider);
+      expect(provider.scheme).toBe('test');
+      expect(provider.uri).toBe('test://resource/path');
+    });
+
+    it('should pass options to provider constructor', () => {
+      const options: ProviderOptions = {
+        trustAuthors: ['user1', 'user2'],
+        trustAllAuthors: false,
+      };
+
+      const provider = createContextProvider(
+        'test://resource',
+        options
+      ) as TestProvider;
+
+      expect(provider.options).toEqual(options);
+    });
+
+    it('should throw ContextUriParseError for malformed URI', () => {
+      expect(() => {
+        createContextProvider('not a valid uri');
+      }).toThrow(ContextUriParseError);
+
+      try {
+        createContextProvider(':::invalid');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ContextUriParseError);
+        expect((error as ContextUriParseError).uri).toBe(':::invalid');
+      }
+    });
+
+    it('should throw ContextSchemeNotSupportedError for unknown scheme', () => {
+      expect(() => {
+        createContextProvider('unknown://resource');
+      }).toThrow(ContextSchemeNotSupportedError);
+
+      try {
+        createContextProvider('ftp://example.com');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ContextSchemeNotSupportedError);
+        expect((error as ContextSchemeNotSupportedError).scheme).toBe('ftp');
+      }
+    });
+
+    it('should correctly extract scheme from URI', () => {
+      registerContextProvider('https', AnotherProvider);
+
+      const provider = createContextProvider('https://example.com/path');
+
+      expect(provider.scheme).toBe('another');
+    });
+  });
+
+  describe('URI parsing', () => {
+    beforeEach(() => {
+      registerContextProvider('github', TestProvider);
+      registerContextProvider('file', TestProvider);
+      registerContextProvider('https', TestProvider);
+    });
+
+    describe('valid URIs', () => {
+      it('should parse custom provider scheme:path format (github:issue/15)', () => {
+        const provider = createContextProvider(
+          'github:issue/15'
+        ) as TestProvider;
+
+        expect(provider.url.protocol).toBe('github:');
+        expect(provider.url.pathname).toBe('issue/15');
+      });
+
+      it('should parse cross-repo reference (github:owner/repo/pr/42)', () => {
+        const provider = createContextProvider(
+          'github:owner/repo/pr/42'
+        ) as TestProvider;
+
+        expect(provider.url.protocol).toBe('github:');
+        expect(provider.url.pathname).toBe('owner/repo/pr/42');
+      });
+
+      it('should parse file URI with absolute path (file:///absolute/path.md)', () => {
+        const provider = createContextProvider(
+          'file:///absolute/path.md'
+        ) as TestProvider;
+
+        expect(provider.url.protocol).toBe('file:');
+        expect(provider.url.pathname).toBe('/absolute/path.md');
+      });
+
+      it('should parse standard https URL', () => {
+        const provider = createContextProvider(
+          'https://example.com/doc.md'
+        ) as TestProvider;
+
+        expect(provider.url.protocol).toBe('https:');
+        expect(provider.url.hostname).toBe('example.com');
+        expect(provider.url.pathname).toBe('/doc.md');
+      });
+
+      it('should parse URI with query parameters', () => {
+        const provider = createContextProvider(
+          'https://example.com/path?foo=bar&baz=qux'
+        ) as TestProvider;
+
+        expect(provider.url.searchParams.get('foo')).toBe('bar');
+        expect(provider.url.searchParams.get('baz')).toBe('qux');
+      });
+
+      it('should parse URI with fragment', () => {
+        const provider = createContextProvider(
+          'https://example.com/doc.md#section'
+        ) as TestProvider;
+
+        expect(provider.url.hash).toBe('#section');
+      });
+    });
+
+    describe('invalid URIs', () => {
+      it('should reject empty URI', () => {
+        expect(() => {
+          createContextProvider('');
+        }).toThrow(ContextUriParseError);
+      });
+
+      it('should reject URI without scheme', () => {
+        expect(() => {
+          createContextProvider('just-a-path');
+        }).toThrow(ContextUriParseError);
+      });
+
+      it('should reject malformed URIs', () => {
+        expect(() => {
+          createContextProvider('://missing-scheme');
+        }).toThrow(ContextUriParseError);
+      });
+    });
+
+    describe('normalization', () => {
+      it('should normalize file:/ to file:///', () => {
+        const provider = createContextProvider(
+          'file:/absolute/path.md'
+        ) as TestProvider;
+
+        // URL API normalizes file:/ to file:///
+        expect(provider.url.href).toBe('file:///absolute/path.md');
+      });
+
+      it('should preserve original URI in provider', () => {
+        const originalUri = 'https://example.com/path';
+        const provider = createContextProvider(originalUri) as TestProvider;
+
+        expect(provider.uri).toBe(originalUri);
+      });
+
+      it('should normalize hostname to lowercase', () => {
+        const provider = createContextProvider(
+          'https://EXAMPLE.COM/path'
+        ) as TestProvider;
+
+        expect(provider.url.hostname).toBe('example.com');
+      });
+    });
+  });
+
+  describe('clearContextProviders', () => {
+    it('should remove all registered providers', () => {
+      registerContextProvider('test', TestProvider);
+      registerContextProvider('another', AnotherProvider);
+
+      clearContextProviders();
+
+      expect(getRegisteredSchemes()).toEqual([]);
+      expect(isContextSchemeSupported('test')).toBe(false);
+      expect(isContextSchemeSupported('another')).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/context/errors.ts
+++ b/packages/core/src/context/errors.ts
@@ -1,0 +1,62 @@
+/**
+ * Base error for context provider operations.
+ */
+export class ContextError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContextError';
+  }
+}
+
+/**
+ * Thrown when a URI scheme is not registered.
+ */
+export class ContextSchemeNotSupportedError extends ContextError {
+  constructor(public readonly scheme: string) {
+    super(`Unsupported context scheme: "${scheme}"`);
+    this.name = 'ContextSchemeNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a URI is malformed or invalid.
+ */
+export class ContextUriParseError extends ContextError {
+  constructor(
+    public readonly uri: string,
+    reason: string
+  ) {
+    super(`Invalid context URI "${uri}": ${reason}`);
+    this.name = 'ContextUriParseError';
+  }
+}
+
+/**
+ * Thrown when a provider doesn't support the requested type.
+ */
+export class ContextTypeNotSupportedError extends ContextError {
+  constructor(
+    public readonly scheme: string,
+    public readonly type: string,
+    public readonly supportedTypes: string[]
+  ) {
+    super(
+      `Provider "${scheme}" does not support type "${type}". ` +
+        `Supported types: ${supportedTypes.join(', ')}`
+    );
+    this.name = 'ContextTypeNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when build() fails to fetch content.
+ */
+export class ContextFetchError extends ContextError {
+  constructor(
+    public readonly uri: string,
+    public readonly reason: string
+  ) {
+    super(`Failed to fetch context from "${uri}": ${reason}`);
+    this.name = 'ContextFetchError';
+  }
+}

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,0 +1,28 @@
+// Types
+export type {
+  ContextEntry,
+  ContextProvider,
+  ContextProviderClass,
+  ProviderOptions,
+} from './types.js';
+
+// Errors
+export {
+  ContextError,
+  ContextSchemeNotSupportedError,
+  ContextUriParseError,
+  ContextTypeNotSupportedError,
+  ContextFetchError,
+} from './errors.js';
+
+// Registry
+export {
+  registerContextProvider,
+  createContextProvider,
+  isContextSchemeSupported,
+  getRegisteredSchemes,
+  clearContextProviders,
+} from './registry.js';
+
+// Providers
+export { registerBuiltInProviders } from './providers/index.js';

--- a/packages/core/src/context/providers/index.ts
+++ b/packages/core/src/context/providers/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Register all built-in context providers.
+ * Call this at application startup.
+ */
+export function registerBuiltInProviders(): void {
+  // Built-in providers will be registered here
+  // FileProvider: see task #487
+  // GitHubProvider: see task #486
+}

--- a/packages/core/src/context/registry.ts
+++ b/packages/core/src/context/registry.ts
@@ -1,0 +1,79 @@
+import type {
+  ContextProvider,
+  ContextProviderClass,
+  ProviderOptions,
+} from './types.js';
+import {
+  ContextSchemeNotSupportedError,
+  ContextUriParseError,
+} from './errors.js';
+
+// Private registry map
+const providers = new Map<string, ContextProviderClass>();
+
+/**
+ * Register a context provider for a given scheme.
+ * @param scheme - The URI scheme (e.g., "github", "file")
+ * @param providerClass - The provider class constructor
+ */
+export function registerContextProvider(
+  scheme: string,
+  providerClass: ContextProviderClass
+): void {
+  providers.set(scheme, providerClass);
+}
+
+/**
+ * Check if a scheme has a registered provider.
+ * @param scheme - The URI scheme to check
+ */
+export function isContextSchemeSupported(scheme: string): boolean {
+  return providers.has(scheme);
+}
+
+/**
+ * Get all registered schemes.
+ */
+export function getRegisteredSchemes(): string[] {
+  return Array.from(providers.keys());
+}
+
+/**
+ * Create a context provider instance for the given URI.
+ *
+ * @param uri - The context URI (e.g., "github:issue/15", "file:./test.md")
+ * @param options - Provider options (trust settings, cwd, etc.)
+ * @throws ContextUriParseError if URI is malformed
+ * @throws ContextSchemeNotSupportedError if scheme has no registered provider
+ */
+export function createContextProvider(
+  uri: string,
+  options?: ProviderOptions
+): ContextProvider {
+  // Parse URI using built-in URL API
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    throw new ContextUriParseError(uri, 'Not a valid URI');
+  }
+
+  // Extract scheme (URL.protocol includes trailing colon)
+  const scheme = url.protocol.slice(0, -1);
+
+  // Lookup provider
+  const ProviderClass = providers.get(scheme);
+  if (!ProviderClass) {
+    throw new ContextSchemeNotSupportedError(scheme);
+  }
+
+  // Instantiate provider with parsed URL (original URI available via url.href)
+  return new ProviderClass(url, options);
+}
+
+/**
+ * Clear all registered providers. Useful for testing.
+ */
+export function clearContextProviders(): void {
+  providers.clear();
+}

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Result entry from a context provider's build() method.
+ * Each entry represents a piece of context to be stored.
+ */
+export type ContextEntry = {
+  /** Display name, e.g., "GitHub Issue #15" */
+  name: string;
+
+  /** Short description for index.md manifest */
+  description: string;
+
+  /** Storage filename, e.g., "github-issue-15.json" */
+  filename: string;
+
+  /** The actual content (stringified JSON, markdown, text) */
+  content: string;
+
+  /** Content type for rendering decisions */
+  type: 'json' | 'markdown' | 'text';
+
+  /** Original URI for provenance tracking */
+  source: string;
+
+  /** Timestamp when content was fetched */
+  fetchedAt: Date;
+};
+
+/**
+ * Options passed to provider constructors.
+ */
+export type ProviderOptions = {
+  /** Trust specific authors for comment inclusion */
+  trustAuthors?: string[];
+
+  /** Trust all authors (skip comment filtering) */
+  trustAllAuthors?: boolean;
+};
+
+/**
+ * Interface that all context providers must implement.
+ */
+export interface ContextProvider {
+  /** The URI scheme this provider handles (e.g., "github", "file") */
+  readonly scheme: string;
+
+  /** Types this provider supports for validation (e.g., ["issue", "pr"]) */
+  readonly supportedTypes: string[];
+
+  /** The original URI passed to the constructor */
+  readonly uri: string;
+
+  /**
+   * Fetch content and build context entries.
+   * @throws ContextFetchError on network/fetch failures
+   */
+  build(): Promise<ContextEntry[]>;
+}
+
+/**
+ * Constructor signature for provider classes.
+ * Receives a parsed URL object (original URI available via url.href).
+ */
+export type ContextProviderClass = new (
+  url: URL,
+  options?: ProviderOptions
+) => ContextProvider;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,3 +91,26 @@ export {
   type AddWorkflowResult,
   type WorkflowEntry,
 } from './files/index.js';
+
+// Context providers
+export {
+  // Types
+  type ContextEntry,
+  type ContextProvider,
+  type ContextProviderClass,
+  type ProviderOptions,
+  // Errors
+  ContextError,
+  ContextSchemeNotSupportedError,
+  ContextUriParseError,
+  ContextTypeNotSupportedError,
+  ContextFetchError,
+  // Registry
+  registerContextProvider,
+  createContextProvider,
+  isContextSchemeSupported,
+  getRegisteredSchemes,
+  clearContextProviders,
+  // Providers
+  registerBuiltInProviders,
+} from './context/index.js';


### PR DESCRIPTION
Adds the core infrastructure for the context provider system in `rover-core`. This establishes the foundation that GitHub, File, and future providers will build upon.

## Changes

- Added `ContextProvider` interface that providers must implement, with `scheme`, `supportedTypes`, `uri`, and `build()` method
- Added `ContextEntry` type representing fetched context data with name, description, filename, content, type, source, and timestamp
- Added provider registry with `registerContextProvider()`, `createContextProvider()`, `isContextSchemeSupported()`, and `getRegisteredSchemes()` functions
- Added custom error classes: `ContextError`, `ContextSchemeNotSupportedError`, `ContextUriParseError`, `ContextTypeNotSupportedError`, and `ContextFetchError`
- Added comprehensive unit tests for the registry (26 tests) and error classes (20 tests)

## Notes

The `ContextProviderClass` constructor receives a parsed `URL` object instead of a string, allowing providers to access all URL components directly without manual parsing. The original URI is available via `url.href`.

Built-in providers (FileProvider, GitHubProvider) will be added in follow-up tasks #486 and #487.

Closes #485