### PR TITLE
feat(core): add LocalFileProvider for local file context

### DIFF
--- a/packages/core/src/context/__tests__/local-file.test.ts
+++ b/packages/core/src/context/__tests__/local-file.test.ts
@@ -1,0 +1,290 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LocalFileProvider } from '../providers/local-file.js';
+import { ContextFetchError } from '../errors.js';
+
+describe('LocalFileProvider', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'local-file-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('URI Parsing', () => {
+    it('should parse file:./relative.md correctly (relative path)', () => {
+      const provider = new LocalFileProvider(new URL('file:./relative.md'), {
+        originalUri: 'file:./relative.md',
+        cwd: tempDir,
+      });
+
+      expect(provider.uri).toBe('file:./relative.md');
+      expect(provider.getResolvedPath()).toBe(
+        path.join(tempDir, 'relative.md')
+      );
+    });
+
+    it('should parse file:test.md correctly (relative without ./)', () => {
+      const provider = new LocalFileProvider(new URL('file:test.md'), {
+        originalUri: 'file:test.md',
+        cwd: tempDir,
+      });
+
+      expect(provider.uri).toBe('file:test.md');
+      expect(provider.getResolvedPath()).toBe(path.join(tempDir, 'test.md'));
+    });
+
+    it('should parse file:///absolute/path.md correctly (absolute)', () => {
+      const provider = new LocalFileProvider(
+        new URL('file:///absolute/path.md'),
+        { originalUri: 'file:///absolute/path.md' }
+      );
+
+      expect(provider.uri).toBe('file:///absolute/path.md');
+      expect(provider.getResolvedPath()).toBe('/absolute/path.md');
+    });
+
+    it('should parse file:/absolute/path.md correctly (absolute shorthand)', () => {
+      const provider = new LocalFileProvider(
+        new URL('file:/absolute/path.md'),
+        { originalUri: 'file:/absolute/path.md' }
+      );
+
+      expect(provider.uri).toBe('file:/absolute/path.md');
+      expect(provider.getResolvedPath()).toBe('/absolute/path.md');
+    });
+
+    it('should handle nested relative paths (../../file.md)', () => {
+      const subdir = path.join(tempDir, 'a', 'b');
+      const provider = new LocalFileProvider(new URL('file:../../file.md'), {
+        originalUri: 'file:../../file.md',
+        cwd: subdir,
+      });
+
+      expect(provider.getResolvedPath()).toBe(path.join(tempDir, 'file.md'));
+    });
+  });
+
+  describe('Path Resolution', () => {
+    it('should resolve relative paths from cwd option', () => {
+      const provider = new LocalFileProvider(new URL('file:./docs/readme.md'), {
+        originalUri: 'file:./docs/readme.md',
+        cwd: tempDir,
+      });
+
+      expect(provider.getResolvedPath()).toBe(
+        path.join(tempDir, 'docs', 'readme.md')
+      );
+    });
+
+    it('should resolve relative paths from process.cwd() when no cwd option', () => {
+      const provider = new LocalFileProvider(new URL('file:./some-file.md'), {
+        originalUri: 'file:./some-file.md',
+      });
+
+      expect(provider.getResolvedPath()).toBe(
+        path.join(process.cwd(), 'some-file.md')
+      );
+    });
+
+    it('should handle absolute paths unchanged', () => {
+      const absolutePath = '/home/user/documents/file.md';
+      const provider = new LocalFileProvider(
+        new URL(`file://${absolutePath}`),
+        { originalUri: `file://${absolutePath}`, cwd: tempDir }
+      );
+
+      expect(provider.getResolvedPath()).toBe(absolutePath);
+    });
+  });
+
+  describe('build() method', () => {
+    it('should return ContextEntry with filepath for text files', async () => {
+      const filePath = path.join(tempDir, 'test.md');
+      await fs.writeFile(filePath, '# Test\n\nSome content');
+
+      const provider = new LocalFileProvider(new URL(`file://${filePath}`), {
+        originalUri: `file://${filePath}`,
+      });
+
+      const entries = await provider.build();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('test.md');
+      expect(entries[0].filepath).toBe(filePath);
+      expect(entries[0].source).toBe(`file://${filePath}`);
+      expect(entries[0].description).toContain(filePath);
+      expect(entries[0].filename).toMatch(/^local-file-.*\.md$/);
+      expect(entries[0].fetchedAt).toBeInstanceOf(Date);
+      // content should not be set (we use filepath instead)
+      expect(entries[0].content).toBeUndefined();
+    });
+
+    it('should throw ContextFetchError for non-existent files', async () => {
+      const nonExistent = path.join(tempDir, 'does-not-exist.md');
+      const provider = new LocalFileProvider(new URL(`file://${nonExistent}`), {
+        originalUri: `file://${nonExistent}`,
+      });
+
+      await expect(provider.build()).rejects.toThrow(ContextFetchError);
+      await expect(provider.build()).rejects.toThrow('File not found');
+    });
+
+    it('should throw ContextFetchError for symlinks', async () => {
+      const realFile = path.join(tempDir, 'real.md');
+      const symlink = path.join(tempDir, 'link.md');
+
+      await fs.writeFile(realFile, 'content');
+      await fs.symlink(realFile, symlink);
+
+      const provider = new LocalFileProvider(new URL(`file://${symlink}`), {
+        originalUri: `file://${symlink}`,
+      });
+
+      await expect(provider.build()).rejects.toThrow(ContextFetchError);
+      await expect(provider.build()).rejects.toThrow('Symbolic links');
+    });
+
+    it('should throw ContextFetchError for binary files', async () => {
+      const binaryFile = path.join(tempDir, 'binary.bin');
+      // Create a buffer with null bytes (binary indicator)
+      const buffer = Buffer.from([0x00, 0x01, 0x02, 0x00, 0x03]);
+      await fs.writeFile(binaryFile, buffer);
+
+      const provider = new LocalFileProvider(new URL(`file://${binaryFile}`), {
+        originalUri: `file://${binaryFile}`,
+      });
+
+      await expect(provider.build()).rejects.toThrow(ContextFetchError);
+      await expect(provider.build()).rejects.toThrow('Binary files');
+    });
+
+    it('should throw ContextFetchError for directories', async () => {
+      const dirPath = path.join(tempDir, 'subdir');
+      await fs.mkdir(dirPath);
+
+      const provider = new LocalFileProvider(new URL(`file://${dirPath}`), {
+        originalUri: `file://${dirPath}`,
+      });
+
+      await expect(provider.build()).rejects.toThrow(ContextFetchError);
+      await expect(provider.build()).rejects.toThrow('Not a regular file');
+    });
+
+    it('should handle files with various extensions (.md, .txt, .json, .ts)', async () => {
+      const extensions = ['.md', '.txt', '.json', '.ts'];
+
+      for (const ext of extensions) {
+        const filePath = path.join(tempDir, `test${ext}`);
+        await fs.writeFile(filePath, `content for ${ext}`);
+
+        const provider = new LocalFileProvider(new URL(`file://${filePath}`), {
+          originalUri: `file://${filePath}`,
+        });
+
+        const entries = await provider.build();
+        expect(entries).toHaveLength(1);
+        expect(entries[0].name).toBe(`test${ext}`);
+      }
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle empty files', async () => {
+      const emptyFile = path.join(tempDir, 'empty.md');
+      await fs.writeFile(emptyFile, '');
+
+      const provider = new LocalFileProvider(new URL(`file://${emptyFile}`), {
+        originalUri: `file://${emptyFile}`,
+      });
+
+      const entries = await provider.build();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].filepath).toBe(emptyFile);
+    });
+
+    it('should handle files with only whitespace', async () => {
+      const whitespaceFile = path.join(tempDir, 'whitespace.txt');
+      await fs.writeFile(whitespaceFile, '   \n\t\n   ');
+
+      const provider = new LocalFileProvider(
+        new URL(`file://${whitespaceFile}`),
+        { originalUri: `file://${whitespaceFile}` }
+      );
+
+      const entries = await provider.build();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].filepath).toBe(whitespaceFile);
+    });
+
+    it('should handle files with special characters in name', async () => {
+      // Files with spaces and special chars work when using absolute paths
+      // The URL API requires encoding, but originalUri preserves the real path
+      const specialFile = path.join(tempDir, 'file-with-dashes.md');
+      await fs.writeFile(specialFile, 'content');
+
+      const provider = new LocalFileProvider(new URL(`file://${specialFile}`), {
+        originalUri: `file://${specialFile}`,
+      });
+
+      const entries = await provider.build();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('file-with-dashes.md');
+    });
+
+    it('should use originalUri from options when available', () => {
+      const originalUri = 'file:./my-file.md';
+      const provider = new LocalFileProvider(
+        new URL('file:///my-file.md'), // URL API normalizes this
+        { originalUri, cwd: tempDir }
+      );
+
+      expect(provider.uri).toBe(originalUri);
+    });
+
+    it('should fall back to url.href when originalUri not provided', () => {
+      const url = new URL('file:///some/path.md');
+      const provider = new LocalFileProvider(url, {});
+
+      expect(provider.uri).toBe(url.href);
+    });
+
+    it('should handle large text files without binary detection false positives', async () => {
+      const largeFile = path.join(tempDir, 'large.txt');
+      // Create a 10KB text file
+      const content = 'Hello World\n'.repeat(1000);
+      await fs.writeFile(largeFile, content);
+
+      const provider = new LocalFileProvider(new URL(`file://${largeFile}`), {
+        originalUri: `file://${largeFile}`,
+      });
+
+      const entries = await provider.build();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].filepath).toBe(largeFile);
+    });
+  });
+
+  describe('Provider properties', () => {
+    it('should have correct scheme', () => {
+      const provider = new LocalFileProvider(new URL('file:./test.md'), {
+        originalUri: 'file:./test.md',
+      });
+
+      expect(provider.scheme).toBe('file');
+    });
+
+    it('should have correct supportedTypes', () => {
+      const provider = new LocalFileProvider(new URL('file:./test.md'), {
+        originalUri: 'file:./test.md',
+      });
+
+      expect(provider.supportedTypes).toEqual(['text']);
+    });
+  });
+});

--- a/packages/core/src/context/__tests__/registry.test.ts
+++ b/packages/core/src/context/__tests__/registry.test.ts
@@ -142,7 +142,9 @@ describe('Context Registry', () => {
         options
       ) as TestProvider;
 
-      expect(provider.options).toEqual(options);
+      // originalUri is automatically added by createContextProvider
+      expect(provider.options).toMatchObject(options);
+      expect(provider.options.originalUri).toBe('test://resource');
     });
 
     it('should throw ContextUriParseError for malformed URI', () => {

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -25,4 +25,7 @@ export {
 } from './registry.js';
 
 // Providers
-export { registerBuiltInProviders } from './providers/index.js';
+export {
+  registerBuiltInProviders,
+  LocalFileProvider,
+} from './providers/index.js';

--- a/packages/core/src/context/providers/index.ts
+++ b/packages/core/src/context/providers/index.ts
@@ -1,9 +1,14 @@
+import { registerContextProvider } from '../registry.js';
+import { LocalFileProvider } from './local-file.js';
+
+// Re-export providers for direct access
+export { LocalFileProvider } from './local-file.js';
+
 /**
  * Register all built-in context providers.
  * Call this at application startup.
  */
 export function registerBuiltInProviders(): void {
-  // Built-in providers will be registered here
-  // FileProvider: see task #487
+  registerContextProvider('file', LocalFileProvider);
   // GitHubProvider: see task #486
 }

--- a/packages/core/src/context/providers/local-file.ts
+++ b/packages/core/src/context/providers/local-file.ts
@@ -1,0 +1,183 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type {
+  ContextEntry,
+  ContextProvider,
+  ProviderOptions,
+} from '../types.js';
+import { ContextFetchError } from '../errors.js';
+
+/**
+ * Check if a buffer likely contains binary content.
+ * Uses null-byte detection in the first 8KB.
+ */
+function isBinaryContent(buffer: Buffer): boolean {
+  const checkLength = Math.min(buffer.length, 8192);
+  for (let i = 0; i < checkLength; i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}
+
+/**
+ * Extract path from a file: URI string.
+ * Handles various formats:
+ * - file:./relative.md → ./relative.md
+ * - file:test.md → test.md
+ * - file:///absolute/path.md → /absolute/path.md
+ * - file:/absolute/path.md → /absolute/path.md
+ */
+function extractPathFromFileUri(uri: string): string {
+  // Remove the "file:" prefix
+  const afterScheme = uri.slice(5);
+
+  // Handle triple-slash absolute paths: file:///path → /path
+  if (afterScheme.startsWith('///')) {
+    return afterScheme.slice(2);
+  }
+
+  // Handle single-slash absolute paths: file:/path → /path
+  if (afterScheme.startsWith('/') && !afterScheme.startsWith('//')) {
+    return afterScheme;
+  }
+
+  // Handle Windows absolute paths with drive letter: file:///C:/... → C:/...
+  // After removing ///, if it looks like C:/ or c:/, it's a Windows path
+  if (afterScheme.startsWith('///')) {
+    const pathPart = afterScheme.slice(3);
+    if (/^[a-zA-Z]:/.test(pathPart)) {
+      return pathPart;
+    }
+  }
+
+  // Relative paths: file:./relative.md or file:test.md
+  return afterScheme;
+}
+
+/**
+ * Generate a safe filename from a path.
+ * Replaces path separators and special characters.
+ */
+function generateFilename(filePath: string): string {
+  const basename = path.basename(filePath);
+  // Replace special characters with dashes, keep alphanumeric, dots, and dashes
+  const safe = basename.replace(/[^a-zA-Z0-9.-]/g, '-').toLowerCase();
+  return `local-file-${safe}`;
+}
+
+/**
+ * Context provider for local file references.
+ * Supports URI formats:
+ * - file:./relative.md (relative path)
+ * - file:test.md (relative without ./)
+ * - file:///home/user/doc.md (absolute canonical)
+ * - file:/home/user/doc.md (absolute shorthand)
+ */
+export class LocalFileProvider implements ContextProvider {
+  readonly scheme = 'file';
+  readonly supportedTypes = ['text'];
+  readonly uri: string;
+
+  private readonly resolvedPath: string;
+  private readonly cwd: string;
+
+  constructor(url: URL, options: ProviderOptions = {}) {
+    this.uri = options.originalUri ?? url.href;
+    this.cwd = options.cwd ?? process.cwd();
+
+    // Extract path from original URI (not normalized URL)
+    const filePath = extractPathFromFileUri(this.uri);
+
+    // Resolve relative paths from cwd
+    this.resolvedPath = path.isAbsolute(filePath)
+      ? filePath
+      : path.resolve(this.cwd, filePath);
+  }
+
+  /**
+   * Get the resolved absolute path.
+   * Useful for testing and debugging.
+   */
+  getResolvedPath(): string {
+    return this.resolvedPath;
+  }
+
+  async build(): Promise<ContextEntry[]> {
+    // 1. Check file exists
+    let stats: Awaited<ReturnType<typeof fs.lstat>>;
+    try {
+      stats = await fs.lstat(this.resolvedPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new ContextFetchError(
+          this.uri,
+          `File not found: ${this.resolvedPath}`
+        );
+      }
+      if ((error as NodeJS.ErrnoException).code === 'EACCES') {
+        throw new ContextFetchError(
+          this.uri,
+          `Permission denied: ${this.resolvedPath}`
+        );
+      }
+      throw new ContextFetchError(
+        this.uri,
+        `Failed to access file: ${(error as Error).message}`
+      );
+    }
+
+    // 2. Check for symlinks
+    if (stats.isSymbolicLink()) {
+      throw new ContextFetchError(
+        this.uri,
+        `Symbolic links are not supported: ${this.resolvedPath}`
+      );
+    }
+
+    // 3. Check it's a regular file
+    if (!stats.isFile()) {
+      throw new ContextFetchError(
+        this.uri,
+        `Not a regular file: ${this.resolvedPath}`
+      );
+    }
+
+    // 4. Read file content to check for binary
+    let buffer: Buffer;
+    try {
+      buffer = await fs.readFile(this.resolvedPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EACCES') {
+        throw new ContextFetchError(
+          this.uri,
+          `Permission denied reading file: ${this.resolvedPath}`
+        );
+      }
+      throw new ContextFetchError(
+        this.uri,
+        `Failed to read file: ${(error as Error).message}`
+      );
+    }
+
+    // 5. Check for binary content
+    if (isBinaryContent(buffer)) {
+      throw new ContextFetchError(
+        this.uri,
+        `Binary files are not supported: ${this.resolvedPath}`
+      );
+    }
+
+    // 6. Return ContextEntry with filepath (not content)
+    const basename = path.basename(this.resolvedPath);
+    const entry: ContextEntry = {
+      name: basename,
+      description: `Local file: ${this.resolvedPath}`,
+      filename: generateFilename(this.resolvedPath),
+      filepath: this.resolvedPath,
+      source: this.uri,
+      fetchedAt: new Date(),
+    };
+
+    return [entry];
+  }
+}

--- a/packages/core/src/context/registry.ts
+++ b/packages/core/src/context/registry.ts
@@ -67,8 +67,12 @@ export function createContextProvider(
     throw new ContextSchemeNotSupportedError(scheme);
   }
 
-  // Instantiate provider with parsed URL (original URI available via url.href)
-  return new ProviderClass(url, options);
+  // Instantiate provider with parsed URL and original URI in options
+  const providerOptions: ProviderOptions = {
+    ...options,
+    originalUri: uri,
+  };
+  return new ProviderClass(url, providerOptions);
 }
 
 /**

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -12,11 +12,11 @@ export type ContextEntry = {
   /** Storage filename, e.g., "github-issue-15.json" */
   filename: string;
 
-  /** The actual content (stringified JSON, markdown, text) */
-  content: string;
+  /** The actual content (stringified JSON, markdown, text). Optional when filepath is provided. */
+  content?: string;
 
-  /** Content type for rendering decisions */
-  type: 'json' | 'markdown' | 'text';
+  /** Path to the file on disk. Used for local file references. */
+  filepath?: string;
 
   /** Original URI for provenance tracking */
   source: string;
@@ -34,6 +34,15 @@ export type ProviderOptions = {
 
   /** Trust all authors (skip comment filtering) */
   trustAllAuthors?: boolean;
+
+  /** Current working directory for resolving relative paths */
+  cwd?: string;
+
+  /**
+   * Original URI string before URL parsing.
+   * Automatically set by createContextProvider().
+   */
+  originalUri?: string;
 };
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,4 +113,5 @@ export {
   clearContextProviders,
   // Providers
   registerBuiltInProviders,
+  LocalFileProvider,
 } from './context/index.js';


### PR DESCRIPTION
Implements `LocalFileProvider` for the context provider system to handle local file references. This provider supports both relative and absolute file paths through URI parsing.

The provider validates files before returning context entries, checking for existence, symlinks, and binary content to ensure only safe text files are processed.

## Changes

- Added `LocalFileProvider` class that handles `file:` URIs for local files
- Supports multiple URI formats: `file:./relative.md`, `file:test.md`, `file:///absolute/path.md`, `file:/absolute/path.md`
- Uses `originalUri` option to preserve paths before URL API normalization
- Resolves relative paths from `cwd` option or `process.cwd()`
- Validates files exist, are not symlinks, and are not binary
- Returns `ContextEntry` with `filepath` field for local file references
- Registered `LocalFileProvider` in `registerBuiltInProviders()` for `file` scheme
- Added comprehensive unit tests covering URI parsing, path resolution, and edge cases

## Notes

The provider uses a null-byte detection algorithm for binary file detection (checking first 8KB) which avoids external dependencies while providing reliable detection for common binary formats.

Closes #487