### PR TITLE
feat: add context manager and workflow integration

### DIFF
--- a/packages/core/src/context/__tests__/index-generator.test.ts
+++ b/packages/core/src/context/__tests__/index-generator.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from 'vitest';
+import type { IterationContextEntry } from 'rover-schemas';
+import { generateContextIndex } from '../index-generator.js';
+
+describe('generateContextIndex', () => {
+  describe('empty entries', () => {
+    it('should generate "No context" message when entries is empty', () => {
+      const result = generateContextIndex([], 1);
+
+      expect(result).toContain('# Context for Iteration 1');
+      expect(result).toContain(
+        'No context sources were provided for this iteration.'
+      );
+    });
+
+    it('should use correct iteration number in header', () => {
+      const result = generateContextIndex([], 5);
+
+      expect(result).toContain('# Context for Iteration 5');
+    });
+  });
+
+  describe('new entries', () => {
+    it('should categorize entries added in current iteration as "New"', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/15',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'github-issue-15.md',
+          name: 'Fix login bug',
+          description: 'GitHub Issue #15',
+          provenance: { addedIn: 2 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 2);
+
+      expect(result).toContain('## New in this iteration');
+      expect(result).toContain(
+        '**Fix login bug** (`github-issue-15.md`) - GitHub Issue #15'
+      );
+    });
+
+    it('should list multiple new entries', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/15',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'github-issue-15.md',
+          name: 'Fix login bug',
+          description: 'GitHub Issue #15',
+          provenance: { addedIn: 1 },
+        },
+        {
+          uri: 'file:./docs/auth.md',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'local-auth-md.md',
+          name: 'auth.md',
+          description: 'Local file ./docs/auth.md',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 1);
+
+      expect(result).toContain('**Fix login bug**');
+      expect(result).toContain('**auth.md**');
+    });
+  });
+
+  describe('updated entries', () => {
+    it('should categorize re-fetched entries as "Updated"', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/15',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'github-issue-15.md',
+          name: 'Fix login bug on mobile',
+          description: 'GitHub Issue #15',
+          provenance: { addedIn: 1, updatedIn: 2 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 2);
+
+      expect(result).toContain('## Updated in this iteration');
+      expect(result).toContain(
+        '**Fix login bug on mobile** (`github-issue-15.md`) - GitHub Issue #15, originally added in iteration 1'
+      );
+    });
+  });
+
+  describe('inherited entries', () => {
+    it('should categorize entries from previous iterations as "From previous"', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'file:./docs/auth.md',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'local-auth-md.md',
+          name: 'auth.md',
+          description: 'Local file',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 3);
+
+      expect(result).toContain('## From previous iterations');
+      expect(result).toContain(
+        '**auth.md** (`local-auth-md.md`) - added in iteration 1'
+      );
+    });
+  });
+
+  describe('mixed entries', () => {
+    it('should correctly categorize a mix of new, updated, and inherited entries', () => {
+      const entries: IterationContextEntry[] = [
+        // New entry
+        {
+          uri: 'github:issue/22',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'github-issue-22.md',
+          name: 'Add user authentication',
+          description: 'GitHub Issue #22',
+          provenance: { addedIn: 2 },
+        },
+        // Updated entry
+        {
+          uri: 'github:issue/15',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'github-issue-15.md',
+          name: 'Fix login bug on mobile',
+          description: 'GitHub Issue #15',
+          provenance: { addedIn: 1, updatedIn: 2 },
+        },
+        // Inherited entry
+        {
+          uri: 'file:./docs/auth.md',
+          fetchedAt: '2024-01-14T08:00:00Z',
+          file: 'local-auth-md.md',
+          name: 'auth.md',
+          description: 'Local file',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 2);
+
+      // Should have all three sections
+      expect(result).toContain('## New in this iteration');
+      expect(result).toContain('## Updated in this iteration');
+      expect(result).toContain('## From previous iterations');
+
+      // Verify entries are in correct sections
+      const lines = result.split('\n');
+      const newSectionIndex = lines.findIndex(l =>
+        l.includes('## New in this iteration')
+      );
+      const updatedSectionIndex = lines.findIndex(l =>
+        l.includes('## Updated in this iteration')
+      );
+      const fromPreviousSectionIndex = lines.findIndex(l =>
+        l.includes('## From previous iterations')
+      );
+
+      // New entry should come after "New" heading
+      const newEntryIndex = lines.findIndex(l =>
+        l.includes('Add user authentication')
+      );
+      expect(newEntryIndex).toBeGreaterThan(newSectionIndex);
+      expect(newEntryIndex).toBeLessThan(updatedSectionIndex);
+
+      // Updated entry should come after "Updated" heading
+      const updatedEntryIndex = lines.findIndex(l =>
+        l.includes('Fix login bug on mobile')
+      );
+      expect(updatedEntryIndex).toBeGreaterThan(updatedSectionIndex);
+      expect(updatedEntryIndex).toBeLessThan(fromPreviousSectionIndex);
+
+      // Inherited entry should come after "From previous" heading
+      const inheritedEntryIndex = lines.findIndex(l => l.includes('auth.md'));
+      expect(inheritedEntryIndex).toBeGreaterThan(fromPreviousSectionIndex);
+    });
+  });
+
+  describe('sources section', () => {
+    it('should include detailed source information', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/22',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'github-issue-22.md',
+          name: 'Add user authentication',
+          description: 'GitHub Issue #22',
+          provenance: { addedIn: 2 },
+          metadata: { type: 'github:issue' },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 2);
+
+      expect(result).toContain('## Sources');
+      expect(result).toContain('### Add user authentication');
+      expect(result).toContain('- **File:** github-issue-22.md');
+      expect(result).toContain('- **URI:** github:issue/22');
+      expect(result).toContain('- **Type:** github:issue');
+      expect(result).toContain('- **Fetched:** 2024-01-15T10:30:00Z');
+      expect(result).toContain('- **Provenance:** added in iteration 2');
+    });
+
+    it('should format provenance for updated entries', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/15',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'github-issue-15.md',
+          name: 'Fix login bug',
+          description: 'GitHub Issue #15',
+          provenance: { addedIn: 1, updatedIn: 2 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 2);
+
+      expect(result).toContain(
+        '- **Provenance:** added in iteration 1, updated in iteration 2'
+      );
+    });
+
+    it('should omit Type field if metadata.type is not present', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'custom://source',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'custom.md',
+          name: 'Custom Entry',
+          description: 'No type metadata',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 1);
+
+      expect(result).toContain('### Custom Entry');
+      expect(result).toContain('- **File:** custom.md');
+      expect(result).toContain('- **URI:** custom://source');
+      expect(result).not.toContain('- **Type:**');
+    });
+  });
+
+  describe('section ordering', () => {
+    it('should only include sections that have entries', () => {
+      // Only new entries
+      const newOnly: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/1',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'issue-1.md',
+          name: 'Issue 1',
+          description: 'New issue',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(newOnly, 1);
+
+      expect(result).toContain('## New in this iteration');
+      expect(result).not.toContain('## Updated in this iteration');
+      expect(result).not.toContain('## From previous iterations');
+    });
+
+    it('should not include empty sections', () => {
+      // Only inherited entries
+      const inheritedOnly: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/1',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'issue-1.md',
+          name: 'Issue 1',
+          description: 'Old issue',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(inheritedOnly, 3);
+
+      expect(result).not.toContain('## New in this iteration');
+      expect(result).not.toContain('## Updated in this iteration');
+      expect(result).toContain('## From previous iterations');
+    });
+  });
+
+  describe('formatting', () => {
+    it('should use proper markdown formatting', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/1',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'issue.md',
+          name: 'Test Issue',
+          description: 'Description',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 1);
+
+      // Check for proper markdown header
+      expect(result.startsWith('# Context for Iteration 1')).toBe(true);
+
+      // Check for proper list formatting
+      expect(result).toMatch(/^- \*\*Test Issue\*\*/m);
+
+      // Check for proper code formatting for filenames
+      expect(result).toContain('`issue.md`');
+    });
+
+    it('should handle special characters in names and descriptions', () => {
+      const entries: IterationContextEntry[] = [
+        {
+          uri: 'github:issue/1',
+          fetchedAt: '2024-01-15T10:30:00Z',
+          file: 'issue.md',
+          name: 'Fix `code` in **markdown**',
+          description: 'Issue with <html> tags',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const result = generateContextIndex(entries, 1);
+
+      // Names and descriptions are included as-is (no escaping)
+      expect(result).toContain('Fix `code` in **markdown**');
+      expect(result).toContain('Issue with <html> tags');
+    });
+  });
+});

--- a/packages/core/src/context/__tests__/manager.test.ts
+++ b/packages/core/src/context/__tests__/manager.test.ts
@@ -1,0 +1,553 @@
+import * as fs from 'node:fs/promises';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { IterationContextEntry } from 'rover-schemas';
+import { ContextManager } from '../manager.js';
+import { registerContextProvider, clearContextProviders } from '../registry.js';
+import { ContextFetchError } from '../errors.js';
+import type {
+  ContextEntry,
+  ContextProvider,
+  ProviderOptions,
+} from '../types.js';
+import type { TaskDescriptionManager } from '../../files/task-description.js';
+import type { IterationManager } from '../../files/iteration.js';
+
+// Mock provider that returns configurable entries
+class MockProvider implements ContextProvider {
+  readonly scheme = 'mock';
+  readonly supportedTypes = ['test'];
+  readonly uri: string;
+  private entries: ContextEntry[];
+  private shouldFail: boolean;
+  private failMessage: string;
+
+  constructor(url: URL, options?: ProviderOptions) {
+    this.uri = options?.originalUri ?? url.href;
+    // Extract configuration from URL search params for testing
+    const params = url.searchParams;
+    this.shouldFail = params.get('fail') === 'true';
+    this.failMessage = params.get('failMessage') ?? 'Mock failure';
+
+    // Default entries based on URL
+    const name = params.get('name') ?? 'Mock Entry';
+    const description = params.get('description') ?? 'A mock context entry';
+    const filename = params.get('filename') ?? 'mock-entry.md';
+    const content = params.get('content') ?? '# Mock Content';
+
+    this.entries = [
+      {
+        name,
+        description,
+        filename,
+        content,
+        source: this.uri,
+        fetchedAt: new Date(),
+        metadata: { type: 'mock:test' },
+      },
+    ];
+  }
+
+  async build(): Promise<ContextEntry[]> {
+    if (this.shouldFail) {
+      throw new ContextFetchError(this.uri, this.failMessage);
+    }
+    return this.entries;
+  }
+}
+
+/**
+ * Create a mock TaskDescriptionManager for testing.
+ */
+function createMockTask(options: {
+  basePath: string;
+  iterations: number;
+  lastIterationContext?: IterationContextEntry[];
+}): TaskDescriptionManager {
+  const iterationsPath = path.join(options.basePath, 'iterations');
+
+  return {
+    getIterationPath: () =>
+      path.join(iterationsPath, options.iterations.toString()),
+    iterations: options.iterations,
+    iterationsPath: () => iterationsPath,
+    getLastIteration: () => {
+      if (!options.lastIterationContext) {
+        return undefined;
+      }
+      return {
+        context: options.lastIterationContext,
+      } as IterationManager;
+    },
+  } as TaskDescriptionManager;
+}
+
+describe('ContextManager', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    clearContextProviders();
+    registerContextProvider('mock', MockProvider);
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'context-manager-test-'));
+  });
+
+  afterEach(async () => {
+    clearContextProviders();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('constructor', () => {
+    it('should create a ContextManager with URIs and task', () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      const manager = new ContextManager(['mock://test'], task);
+
+      expect(manager.getContextDir()).toBe(
+        path.join(tempDir, 'iterations', '1', 'context')
+      );
+    });
+
+    it('should create a ContextManager with empty URIs', () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      const manager = new ContextManager([], task);
+
+      expect(manager.getContextDir()).toBe(
+        path.join(tempDir, 'iterations', '1', 'context')
+      );
+    });
+  });
+
+  describe('fetchAndStore', () => {
+    it('should create context directory even with no URIs', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      const manager = new ContextManager([], task);
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toEqual([]);
+      expect(existsSync(manager.getContextDir())).toBe(true);
+    });
+
+    it('should fetch and store a single context entry', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://test?name=Test%20Entry&filename=test.md'],
+        task
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('Test Entry');
+      expect(entries[0].file).toBe('test.md');
+      expect(entries[0].provenance.addedIn).toBe(1);
+      expect(entries[0].provenance.updatedIn).toBeUndefined();
+
+      // File should be written
+      const filePath = path.join(manager.getContextDir(), 'test.md');
+      expect(existsSync(filePath)).toBe(true);
+      expect(readFileSync(filePath, 'utf8')).toBe('# Mock Content');
+    });
+
+    it('should fetch multiple context entries', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        [
+          'mock://test1?name=First&filename=first.md',
+          'mock://test2?name=Second&filename=second.md',
+        ],
+        task
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0].name).toBe('First');
+      expect(entries[1].name).toBe('Second');
+    });
+
+    it('should fail if any provider fails', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        [
+          'mock://test1?name=First&filename=first.md',
+          'mock://test2?fail=true&failMessage=Network%20error',
+        ],
+        task
+      );
+
+      await expect(manager.fetchAndStore()).rejects.toThrow(ContextFetchError);
+      await expect(manager.fetchAndStore()).rejects.toThrow('Network error');
+    });
+
+    it('should pass trust settings to providers', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://test?name=Test&filename=test.md'],
+        task,
+        {
+          trustAllAuthors: true,
+          trustedAuthors: ['alice', 'bob'],
+        }
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].trustSettings).toEqual({
+        trustAllAuthors: true,
+        trustedAuthors: ['alice', 'bob'],
+      });
+    });
+
+    it('should not include trust settings if not provided', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://test?name=Test&filename=test.md'],
+        task
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].trustSettings).toBeUndefined();
+    });
+  });
+
+  describe('inheritance from previous iteration', () => {
+    it('should inherit entries from previous iteration', async () => {
+      // Set up previous iteration files
+      const prevContextDir = path.join(tempDir, 'iterations', '1', 'context');
+      mkdirSync(prevContextDir, { recursive: true });
+      writeFileSync(path.join(prevContextDir, 'prev.md'), '# Previous Content');
+
+      const previousContext: IterationContextEntry[] = [
+        {
+          uri: 'mock://previous',
+          fetchedAt: '2024-01-01T00:00:00Z',
+          file: 'prev.md',
+          name: 'Previous Entry',
+          description: 'From previous iteration',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      // Current iteration (2) with previous context
+      const task = createMockTask({
+        basePath: tempDir,
+        iterations: 2,
+        lastIterationContext: previousContext,
+      });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager([], task);
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('Previous Entry');
+      expect(entries[0].provenance.addedIn).toBe(1);
+      expect(entries[0].provenance.updatedIn).toBeUndefined();
+
+      // File should be copied
+      const filePath = path.join(manager.getContextDir(), 'prev.md');
+      expect(existsSync(filePath)).toBe(true);
+      expect(readFileSync(filePath, 'utf8')).toBe('# Previous Content');
+    });
+
+    it('should re-fetch entries when URI is in new URIs list', async () => {
+      // Set up previous iteration files
+      const prevContextDir = path.join(tempDir, 'iterations', '1', 'context');
+      mkdirSync(prevContextDir, { recursive: true });
+      writeFileSync(path.join(prevContextDir, 'refetch.md'), '# Old Content');
+
+      const sharedUri =
+        'mock://shared?name=Shared&filename=refetch.md&content=%23%20New%20Content';
+      const previousContext: IterationContextEntry[] = [
+        {
+          uri: sharedUri,
+          fetchedAt: '2024-01-01T00:00:00Z',
+          file: 'refetch.md',
+          name: 'Shared Entry',
+          description: 'Will be re-fetched',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      // Current iteration with same URI
+      const task = createMockTask({
+        basePath: tempDir,
+        iterations: 2,
+        lastIterationContext: previousContext,
+      });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager([sharedUri], task);
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('Shared');
+      // Should have updatedIn since it was re-fetched
+      expect(entries[0].provenance.addedIn).toBe(1);
+      expect(entries[0].provenance.updatedIn).toBe(2);
+    });
+
+    it('should combine inherited and new entries', async () => {
+      // Set up previous iteration files
+      const prevContextDir = path.join(tempDir, 'iterations', '1', 'context');
+      mkdirSync(prevContextDir, { recursive: true });
+      writeFileSync(path.join(prevContextDir, 'inherited.md'), '# Inherited');
+
+      const previousContext: IterationContextEntry[] = [
+        {
+          uri: 'mock://inherited',
+          fetchedAt: '2024-01-01T00:00:00Z',
+          file: 'inherited.md',
+          name: 'Inherited Entry',
+          description: 'From previous',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      // Current iteration with new URI
+      const task = createMockTask({
+        basePath: tempDir,
+        iterations: 2,
+        lastIterationContext: previousContext,
+      });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://new?name=New%20Entry&filename=new.md'],
+        task
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(2);
+
+      const inherited = entries.find(e => e.name === 'Inherited Entry');
+      const newEntry = entries.find(e => e.name === 'New Entry');
+
+      expect(inherited).toBeDefined();
+      expect(inherited!.provenance.addedIn).toBe(1);
+      expect(inherited!.provenance.updatedIn).toBeUndefined();
+
+      expect(newEntry).toBeDefined();
+      expect(newEntry!.provenance.addedIn).toBe(2);
+      expect(newEntry!.provenance.updatedIn).toBeUndefined();
+    });
+
+    it('should handle missing previous context file gracefully', async () => {
+      // Set up previous iteration but don't create the file
+      const prevContextDir = path.join(tempDir, 'iterations', '1', 'context');
+      mkdirSync(prevContextDir, { recursive: true });
+      // Don't write the file
+
+      const previousContext: IterationContextEntry[] = [
+        {
+          uri: 'mock://missing-file',
+          fetchedAt: '2024-01-01T00:00:00Z',
+          file: 'missing.md',
+          name: 'Missing Entry',
+          description: 'File was deleted',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const task = createMockTask({
+        basePath: tempDir,
+        iterations: 2,
+        lastIterationContext: previousContext,
+      });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager([], task);
+
+      const entries = await manager.fetchAndStore();
+
+      // Entry should still be inherited (metadata preserved)
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('Missing Entry');
+
+      // But file won't exist in new context (copy failed silently)
+      const filePath = path.join(manager.getContextDir(), 'missing.md');
+      expect(existsSync(filePath)).toBe(false);
+    });
+
+    it('should not inherit when iteration is 1', async () => {
+      // First iteration has no previous context to inherit
+      const task = createMockTask({
+        basePath: tempDir,
+        iterations: 1,
+        lastIterationContext: undefined,
+      });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://test?name=First&filename=first.md'],
+        task
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].provenance.addedIn).toBe(1);
+    });
+  });
+
+  describe('provenance tracking', () => {
+    it('should set addedIn for new entries', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 3 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://test?name=New&filename=new.md'],
+        task
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries[0].provenance).toEqual({ addedIn: 3 });
+    });
+
+    it('should preserve addedIn and set updatedIn for re-fetched entries', async () => {
+      const prevContextDir = path.join(tempDir, 'iterations', '2', 'context');
+      mkdirSync(prevContextDir, { recursive: true });
+
+      const sharedUri = 'mock://shared?name=Shared&filename=shared.md';
+      const previousContext: IterationContextEntry[] = [
+        {
+          uri: sharedUri,
+          fetchedAt: '2024-01-01T00:00:00Z',
+          file: 'shared.md',
+          name: 'Shared',
+          description: 'Original',
+          provenance: { addedIn: 1 },
+        },
+      ];
+
+      const task = createMockTask({
+        basePath: tempDir,
+        iterations: 3,
+        lastIterationContext: previousContext,
+      });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager([sharedUri], task);
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries[0].provenance).toEqual({
+        addedIn: 1,
+        updatedIn: 3,
+      });
+    });
+
+    it('should preserve original provenance for inherited entries', async () => {
+      const prevContextDir = path.join(tempDir, 'iterations', '4', 'context');
+      mkdirSync(prevContextDir, { recursive: true });
+      writeFileSync(path.join(prevContextDir, 'old.md'), '# Old');
+
+      const previousContext: IterationContextEntry[] = [
+        {
+          uri: 'mock://old',
+          fetchedAt: '2024-01-01T00:00:00Z',
+          file: 'old.md',
+          name: 'Old Entry',
+          description: 'Very old',
+          provenance: { addedIn: 1, updatedIn: 2 },
+        },
+      ];
+
+      const task = createMockTask({
+        basePath: tempDir,
+        iterations: 5,
+        lastIterationContext: previousContext,
+      });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager([], task);
+
+      const entries = await manager.fetchAndStore();
+
+      // Inherited entries should have addedIn only (no updatedIn since not re-fetched)
+      expect(entries[0].provenance).toEqual({ addedIn: 1 });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should wrap non-ContextFetchError errors', async () => {
+      // Register a provider that throws a generic error
+      class ThrowingProvider implements ContextProvider {
+        readonly scheme = 'throwing';
+        readonly supportedTypes = ['test'];
+        readonly uri: string;
+
+        constructor(url: URL, options?: ProviderOptions) {
+          this.uri = options?.originalUri ?? url.href;
+        }
+
+        async build(): Promise<ContextEntry[]> {
+          throw new Error('Generic error');
+        }
+      }
+
+      registerContextProvider('throwing', ThrowingProvider);
+
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(['throwing://test'], task);
+
+      await expect(manager.fetchAndStore()).rejects.toThrow(ContextFetchError);
+      await expect(manager.fetchAndStore()).rejects.toThrow('Generic error');
+    });
+
+    it('should preserve ContextFetchError without wrapping', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://test?fail=true&failMessage=Original%20error'],
+        task
+      );
+
+      try {
+        await manager.fetchAndStore();
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ContextFetchError);
+        expect((error as ContextFetchError).reason).toBe('Original error');
+      }
+    });
+  });
+
+  describe('metadata handling', () => {
+    it('should include provider metadata in entries', async () => {
+      const task = createMockTask({ basePath: tempDir, iterations: 1 });
+      mkdirSync(task.getIterationPath(), { recursive: true });
+
+      const manager = new ContextManager(
+        ['mock://test?name=Test&filename=test.md'],
+        task
+      );
+
+      const entries = await manager.fetchAndStore();
+
+      expect(entries[0].metadata).toEqual({ type: 'mock:test' });
+    });
+  });
+});

--- a/packages/core/src/context/index-generator.ts
+++ b/packages/core/src/context/index-generator.ts
@@ -1,0 +1,121 @@
+/**
+ * Context Index Generator - Generates the index.md manifest for context entries.
+ *
+ * The index.md file provides a human-readable overview of all context sources
+ * for an iteration, categorized by:
+ * - New in this iteration
+ * - Updated in this iteration (re-fetched)
+ * - From previous iterations (inherited)
+ */
+import type { IterationContextEntry } from 'rover-schemas';
+
+/**
+ * Generate the index.md content for context entries.
+ *
+ * @param entries - All context entries for this iteration
+ * @param iterationNumber - Current iteration number
+ * @returns Markdown content for index.md
+ */
+export function generateContextIndex(
+  entries: IterationContextEntry[],
+  iterationNumber: number
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# Context for Iteration ${iterationNumber}`);
+  lines.push('');
+
+  if (entries.length === 0) {
+    lines.push('No context sources were provided for this iteration.');
+    return lines.join('\n');
+  }
+
+  // Categorize entries
+  const newEntries: IterationContextEntry[] = [];
+  const updatedEntries: IterationContextEntry[] = [];
+  const inheritedEntries: IterationContextEntry[] = [];
+
+  for (const entry of entries) {
+    if (entry.provenance.addedIn === iterationNumber) {
+      // Newly added in this iteration
+      newEntries.push(entry);
+    } else if (entry.provenance.updatedIn === iterationNumber) {
+      // Re-fetched/updated in this iteration
+      updatedEntries.push(entry);
+    } else {
+      // Inherited from previous iteration
+      inheritedEntries.push(entry);
+    }
+  }
+
+  // New entries section
+  if (newEntries.length > 0) {
+    lines.push('## New in this iteration');
+    for (const entry of newEntries) {
+      lines.push(
+        `- **${entry.name}** (\`${entry.file}\`) - ${entry.description}`
+      );
+    }
+    lines.push('');
+  }
+
+  // Updated entries section
+  if (updatedEntries.length > 0) {
+    lines.push('## Updated in this iteration');
+    for (const entry of updatedEntries) {
+      lines.push(
+        `- **${entry.name}** (\`${entry.file}\`) - ${entry.description}, originally added in iteration ${entry.provenance.addedIn}`
+      );
+    }
+    lines.push('');
+  }
+
+  // Inherited entries section
+  if (inheritedEntries.length > 0) {
+    lines.push('## From previous iterations');
+    for (const entry of inheritedEntries) {
+      lines.push(
+        `- **${entry.name}** (\`${entry.file}\`) - added in iteration ${entry.provenance.addedIn}`
+      );
+    }
+    lines.push('');
+  }
+
+  // Detailed sources section
+  lines.push('## Sources');
+  lines.push('');
+
+  for (const entry of entries) {
+    lines.push(`### ${entry.name}`);
+    lines.push(`- **File:** ${entry.file}`);
+    lines.push(`- **URI:** ${entry.uri}`);
+
+    if (entry.metadata?.type) {
+      lines.push(`- **Type:** ${entry.metadata.type}`);
+    }
+
+    lines.push(`- **Fetched:** ${entry.fetchedAt}`);
+    lines.push(
+      `- **Provenance:** ${formatProvenance(entry.provenance, iterationNumber)}`
+    );
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format provenance information for display.
+ */
+function formatProvenance(
+  provenance: IterationContextEntry['provenance'],
+  currentIteration: number
+): string {
+  if (provenance.updatedIn === currentIteration) {
+    return `added in iteration ${provenance.addedIn}, updated in iteration ${provenance.updatedIn}`;
+  } else if (provenance.addedIn === currentIteration) {
+    return `added in iteration ${provenance.addedIn}`;
+  } else {
+    return `added in iteration ${provenance.addedIn}`;
+  }
+}

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -38,3 +38,9 @@ export {
   GitHubProvider,
   HTTPSProvider,
 } from './providers/index.js';
+
+// Manager
+export { ContextManager, type ContextManagerOptions } from './manager.js';
+
+// Index Generator
+export { generateContextIndex } from './index-generator.js';

--- a/packages/core/src/context/manager.ts
+++ b/packages/core/src/context/manager.ts
@@ -1,0 +1,289 @@
+/**
+ * Context Manager - Orchestrates fetching, storage, and inheritance of context entries.
+ *
+ * The ContextManager handles:
+ * 1. Fetching new context from URIs using registered providers
+ * 2. Inheriting context from previous iterations
+ * 3. Writing context files to the iteration's context folder
+ * 4. Tracking provenance (when context was added/updated)
+ */
+import { existsSync, mkdirSync, writeFileSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type {
+  IterationContextEntry,
+  TrustSettings,
+  Provenance,
+} from 'rover-schemas';
+import { createContextProvider } from './registry.js';
+import { ContextFetchError } from './errors.js';
+import type { ContextEntry, ProviderOptions } from './types.js';
+import type { TaskDescriptionManager } from '../files/task-description.js';
+
+/**
+ * Options for the ContextManager.
+ */
+export interface ContextManagerOptions {
+  /** Trust all authors for comment inclusion */
+  trustAllAuthors?: boolean;
+  /** Trust specific authors for comment inclusion */
+  trustedAuthors?: string[];
+  /** Current working directory for resolving relative paths */
+  cwd?: string;
+}
+
+/**
+ * Context Manager class that orchestrates fetching, storage, and inheritance of context.
+ */
+export class ContextManager {
+  private uris: string[];
+  private task: TaskDescriptionManager;
+  private options: ContextManagerOptions;
+  private contextDir: string;
+
+  /**
+   * Create a new ContextManager.
+   *
+   * @param uris - URIs to fetch context from (from CLI --context flags)
+   * @param task - The task description manager instance
+   * @param options - Trust settings and other options
+   */
+  constructor(
+    uris: string[],
+    task: TaskDescriptionManager,
+    options?: ContextManagerOptions
+  ) {
+    this.uris = uris;
+    this.task = task;
+    this.options = options ?? {};
+    this.contextDir = join(task.getIterationPath(), 'context');
+  }
+
+  /**
+   * Main orchestration: fetch new context, inherit previous, write files, return entries.
+   *
+   * @returns Array of all context entries (inherited + new)
+   * @throws ContextFetchError if any provider fails
+   */
+  async fetchAndStore(): Promise<IterationContextEntry[]> {
+    // Always create context directory
+    this.ensureContextDir();
+
+    // Get new URIs as a Set for fast lookup
+    const newUriSet = new Set(this.uris);
+
+    // Inherit entries from previous iteration that are not being re-fetched
+    const inheritedEntries = await this.inheritPreviousContext(newUriSet);
+
+    // Fetch new context entries
+    const newEntries = await this.fetchNewContext();
+
+    // Combine inherited and new entries
+    return [...inheritedEntries, ...newEntries];
+  }
+
+  /**
+   * Get the path to the context directory.
+   */
+  getContextDir(): string {
+    return this.contextDir;
+  }
+
+  /**
+   * Ensure the context directory exists.
+   */
+  private ensureContextDir(): void {
+    if (!existsSync(this.contextDir)) {
+      mkdirSync(this.contextDir, { recursive: true });
+    }
+  }
+
+  /**
+   * Get context entries from the previous iteration.
+   */
+  private getPreviousContext(): IterationContextEntry[] {
+    const lastIteration = this.task.getLastIteration();
+    return lastIteration?.context ?? [];
+  }
+
+  /**
+   * Get the path to the previous iteration directory.
+   */
+  private getPreviousIterationPath(): string | undefined {
+    const currentIteration = this.task.iterations;
+    if (currentIteration <= 1) {
+      return undefined;
+    }
+    return join(this.task.iterationsPath(), (currentIteration - 1).toString());
+  }
+
+  /**
+   * Inherit context entries from the previous iteration.
+   * Only inherits entries whose URIs are not in the new URIs list.
+   */
+  private async inheritPreviousContext(
+    newUriSet: Set<string>
+  ): Promise<IterationContextEntry[]> {
+    const previousContext = this.getPreviousContext();
+    const previousIterationPath = this.getPreviousIterationPath();
+    const inheritedEntries: IterationContextEntry[] = [];
+
+    for (const prevEntry of previousContext) {
+      // Skip if this URI will be re-fetched
+      if (newUriSet.has(prevEntry.uri)) {
+        continue;
+      }
+
+      // Copy the file from previous iteration
+      if (previousIterationPath) {
+        const sourcePath = join(
+          previousIterationPath,
+          'context',
+          prevEntry.file
+        );
+        const destPath = join(this.contextDir, prevEntry.file);
+
+        if (existsSync(sourcePath)) {
+          copyFileSync(sourcePath, destPath);
+        }
+      }
+
+      // Keep the entry with original provenance (no updatedIn)
+      inheritedEntries.push({
+        ...prevEntry,
+        // Ensure provenance is preserved exactly
+        provenance: {
+          addedIn: prevEntry.provenance.addedIn,
+          // Don't set updatedIn for inherited entries
+        },
+      });
+    }
+
+    return inheritedEntries;
+  }
+
+  /**
+   * Fetch new context entries from the configured URIs.
+   */
+  private async fetchNewContext(): Promise<IterationContextEntry[]> {
+    const entries: IterationContextEntry[] = [];
+    const previousContext = this.getPreviousContext();
+
+    // Build a map of previous entries by URI for re-fetch detection
+    const previousByUri = new Map<string, IterationContextEntry>();
+    for (const entry of previousContext) {
+      previousByUri.set(entry.uri, entry);
+    }
+
+    for (const uri of this.uris) {
+      // Build provider options from manager options
+      const providerOptions: ProviderOptions = {
+        trustAllAuthors: this.options.trustAllAuthors,
+        trustAuthors: this.options.trustedAuthors,
+        cwd: this.options.cwd,
+      };
+
+      // Create provider and fetch content
+      const provider = createContextProvider(uri, providerOptions);
+      let contextEntries: ContextEntry[];
+
+      try {
+        contextEntries = await provider.build();
+      } catch (error) {
+        // Re-throw as ContextFetchError if it isn't already
+        if (error instanceof ContextFetchError) {
+          throw error;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        throw new ContextFetchError(uri, message);
+      }
+
+      // Process each entry from the provider
+      for (const contextEntry of contextEntries) {
+        // Write content to file
+        const filePath = join(this.contextDir, contextEntry.filename);
+        this.writeContextFile(filePath, contextEntry);
+
+        // Determine provenance
+        const previousEntry = previousByUri.get(uri);
+        const provenance: Provenance = this.determineProvenance(previousEntry);
+
+        // Build trust settings
+        const trustSettings = this.buildTrustSettings();
+
+        // Create iteration context entry
+        const iterationEntry: IterationContextEntry = {
+          uri: contextEntry.source,
+          fetchedAt: contextEntry.fetchedAt.toISOString(),
+          file: contextEntry.filename,
+          name: contextEntry.name,
+          description: contextEntry.description,
+          provenance,
+          ...(trustSettings && { trustSettings }),
+          ...(contextEntry.metadata && {
+            metadata:
+              contextEntry.metadata as IterationContextEntry['metadata'],
+          }),
+        };
+
+        entries.push(iterationEntry);
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Determine provenance for a new/updated entry.
+   */
+  private determineProvenance(
+    previousEntry?: IterationContextEntry
+  ): Provenance {
+    const currentIteration = this.task.iterations;
+
+    if (previousEntry) {
+      // Re-fetched entry: keep original addedIn, set updatedIn
+      return {
+        addedIn: previousEntry.provenance.addedIn,
+        updatedIn: currentIteration,
+      };
+    } else {
+      // New entry: set addedIn to current iteration
+      return {
+        addedIn: currentIteration,
+      };
+    }
+  }
+
+  /**
+   * Build trust settings from options.
+   */
+  private buildTrustSettings(): TrustSettings | undefined {
+    if (
+      this.options.trustAllAuthors === undefined &&
+      !this.options.trustedAuthors?.length
+    ) {
+      return undefined;
+    }
+
+    return {
+      ...(this.options.trustAllAuthors !== undefined && {
+        trustAllAuthors: this.options.trustAllAuthors,
+      }),
+      ...(this.options.trustedAuthors?.length && {
+        trustedAuthors: this.options.trustedAuthors,
+      }),
+    };
+  }
+
+  /**
+   * Write context entry content to file.
+   */
+  private writeContextFile(filePath: string, entry: ContextEntry): void {
+    if (entry.content) {
+      writeFileSync(filePath, entry.content, 'utf8');
+    } else if (entry.filepath) {
+      // For local files, copy the file
+      copyFileSync(entry.filepath, filePath);
+    }
+  }
+}

--- a/packages/core/src/files/iteration.ts
+++ b/packages/core/src/files/iteration.ts
@@ -255,6 +255,17 @@ export class IterationManager {
   }
 
   /**
+   * Set the context entries for this iteration.
+   * Used by ContextManager after fetching and storing context files.
+   *
+   * @param entries - Context entries to store
+   */
+  setContext(entries: IterationContextEntry[]): void {
+    this.data.context = entries;
+    this.save();
+  }
+
+  /**
    * Get raw JSON data
    */
   toJSON(): Iteration {


### PR DESCRIPTION
Implements the context manager to orchestrate fetching, storage, and inheritance of context entries. This enables the new context system to fetch external context (GitHub issues, local files, HTTPS resources) and track provenance across iterations.

## Changes

- Added `ContextManager` class in `packages/core/src/context/manager.ts` that:
  - Accepts URIs from CLI `--context` flags and a `TaskDescriptionManager` instance
  - Fetches context from registered providers (GitHub, file, HTTPS)
  - Inherits context from previous iterations (copies files, preserves metadata)
  - Re-fetches entries when the same URI is provided again
  - Tracks provenance (`addedIn`/`updatedIn`) for all entries
  - Creates the `context/` directory structure

- Added `generateContextIndex()` function in `packages/core/src/context/index-generator.ts` that:
  - Generates human-readable `index.md` manifest
  - Categorizes entries as "New", "Updated", or "From previous iterations"
  - Includes detailed source information with provenance

- Added `setContext()` method to `IterationManager` for storing context entries

- Added comprehensive unit tests for both `ContextManager` and `generateContextIndex`

## Notes

This PR builds on #498 which added the context schema. The CLI `--context` flag implementation and prompt injection in `packages/agent` are separate tasks.

Closes #489