### PR TITLE
chore: allow to restart task whose container is no longer running

### DIFF
--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -76,19 +76,46 @@ const restartCommand = async (
       throw new TaskNotFoundError(numericTaskId);
     }
 
-    // Check if task is in NEW or FAILED status
+    // Check if task is in a restartable status
     if (!task.isNew() && !task.isFailed()) {
-      jsonOutput.error = `Task ${taskId} is not in NEW or FAILED status (current: ${task.status})`;
-      await exitWithError(jsonOutput, {
-        tips: [
-          'Only NEW and FAILED tasks can be restarted',
-          'Use ' +
-            colors.cyan(`rover inspect ${taskId}`) +
-            colors.gray(' to find out the current task status'),
-        ],
-        telemetry,
-      });
-      return;
+      if (task.isInProgress()) {
+        // Allow restarting IN_PROGRESS tasks if the container is dead
+        try {
+          const sandbox = await createSandbox(task, undefined, {
+            projectPath: project.path,
+          });
+          const state = await sandbox.inspect();
+          // Container is still running — reject the restart
+          if (state && state.status === 'running') {
+            jsonOutput.error = `Task ${taskId} is IN_PROGRESS and its container is still running`;
+            await exitWithError(jsonOutput, {
+              tips: [
+                'The container for this task is still running',
+                'Use ' +
+                  colors.cyan(`rover logs -f ${taskId}`) +
+                  colors.gray(' to watch the task logs'),
+              ],
+              telemetry,
+            });
+            return;
+          }
+          // Container is dead (exited or not found) — allow restart to proceed
+        } catch {
+          // If we can't inspect (e.g. no backend available), allow restart
+        }
+      } else {
+        jsonOutput.error = `Task ${taskId} is not in NEW or FAILED status (current: ${task.status})`;
+        await exitWithError(jsonOutput, {
+          tips: [
+            'Only NEW, FAILED, and stuck IN_PROGRESS tasks can be restarted',
+            'Use ' +
+              colors.cyan(`rover inspect ${taskId}`) +
+              colors.gray(' to find out the current task status'),
+          ],
+          telemetry,
+        });
+        return;
+      }
     }
 
     // Restart the task (resets to NEW status and tracks restart attempt)
@@ -262,7 +289,7 @@ export { restartCommand };
 
 export default {
   name: 'restart',
-  description: 'Restart a new or failed task',
+  description: 'Restart a new, failed, or stuck in-progress task',
   requireProject: true,
   action: restartCommand,
 } satisfies CommandDefinition;

--- a/packages/cli/src/lib/sandbox/docker.ts
+++ b/packages/cli/src/lib/sandbox/docker.ts
@@ -543,6 +543,20 @@ export class DockerSandbox extends Sandbox {
     return process.env;
   }
 
+  async inspect(): Promise<{ status: string } | null> {
+    try {
+      const result = await launch(
+        'docker',
+        ['inspect', '--format', '{{.State.Status}}', this.sandboxName],
+        { env: this.getDockerEnv() }
+      );
+      const status = result.stdout?.toString().trim();
+      return status ? { status } : null;
+    } catch {
+      return null;
+    }
+  }
+
   protected async remove(): Promise<string> {
     return (
       (

--- a/packages/cli/src/lib/sandbox/podman.ts
+++ b/packages/cli/src/lib/sandbox/podman.ts
@@ -499,6 +499,20 @@ export class PodmanSandbox extends Sandbox {
     });
   }
 
+  async inspect(): Promise<{ status: string } | null> {
+    try {
+      const result = await launch(
+        'podman',
+        ['inspect', '--format', '{{.State.Status}}', this.sandboxName],
+        { stdio: 'pipe' }
+      );
+      const status = result.stdout?.toString().trim();
+      return status ? { status } : null;
+    } catch {
+      return null;
+    }
+  }
+
   protected async remove(): Promise<string> {
     return (
       (

--- a/packages/cli/src/lib/sandbox/types.ts
+++ b/packages/cli/src/lib/sandbox/types.ts
@@ -45,6 +45,7 @@ export abstract class Sandbox {
 
   abstract isBackendAvailable(): Promise<boolean>;
   abstract openShellAtWorktree(): Promise<void>;
+  abstract inspect(): Promise<{ status: string } | null>;
 
   protected abstract create(): Promise<string>;
   protected abstract start(): Promise<string>;


### PR DESCRIPTION
Allow restarting `IN_PROGRESS` tasks when their container has stopped running (e.g. crashed or exited). Previously, only `NEW` and `FAILED` tasks could be restarted, which meant stuck tasks with dead containers required manual intervention.

The restart command now inspects the container state before rejecting an `IN_PROGRESS` task. If the container is no longer running, the restart proceeds normally. If the container is still active, the restart is rejected with an informative message.

## Changes

- Added abstract `inspect()` method to the `Sandbox` base class that returns the container status
- Implemented `inspect()` in `DockerSandbox` and `PodmanSandbox` using `docker inspect` / `podman inspect`
- Updated `restart` command to check container liveness for `IN_PROGRESS` tasks before deciding whether to allow the restart
- Updated command description to reflect the new behavior: *"Restart a new, failed, or stuck in-progress task"*
- Added tests for restarting `IN_PROGRESS` tasks with dead and running containers, and for rejecting `COMPLETED` tasks

Fixes: #509
cc/ @dataforxyz 