### PR TITLE
chore: replace positional parameters with options object in agent invoke

### DIFF
--- a/packages/cli/src/lib/agents/codex.ts
+++ b/packages/cli/src/lib/agents/codex.ts
@@ -3,6 +3,7 @@ import {
   AIAgentTool,
   InvokeAIAgentError,
   MissingAIAgentError,
+  type InvokeOptions,
 } from './index.js';
 import { PromptBuilder, IPromptTask } from '../prompts/index.js';
 import { parseJsonResponse } from '../../utils/json-parser.js';
@@ -38,13 +39,15 @@ class CodexAI implements AIAgentTool {
     }
   }
 
-  async invoke(
-    prompt: string,
-    json: boolean = false,
-    cwd?: string
-  ): Promise<string> {
+  async invoke(prompt: string, options: InvokeOptions = {}): Promise<string> {
+    const { json = false, cwd, model } = options;
     const answerTmpFile = fileSync();
     const codexArgs = ['exec', '--output-last-message', answerTmpFile.name];
+
+    if (model) {
+      codexArgs.push('--model', model);
+    }
+
     if (json) {
       // Codex does not have any way to force the JSON output at CLI level.
       // Trying to force it via prompting
@@ -77,7 +80,10 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     );
 
     try {
-      const response = await this.invoke(prompt, true, projectPath);
+      const response = await this.invoke(prompt, {
+        json: true,
+        cwd: projectPath,
+      });
       return parseJsonResponse<IPromptTask>(response);
     } catch (error) {
       console.error('Failed to expand task with Codex:', error);
@@ -99,7 +105,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     );
 
     try {
-      const response = await this.invoke(prompt, true);
+      const response = await this.invoke(prompt, { json: true });
       return parseJsonResponse<IPromptTask>(response);
     } catch (error) {
       console.error(
@@ -123,7 +129,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
         recentCommits,
         summaries
       );
-      const response = await this.invoke(prompt, false);
+      const response = await this.invoke(prompt);
 
       if (!response) {
         return null;
@@ -150,7 +156,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
         diffContext,
         conflictedContent
       );
-      const response = await this.invoke(prompt, false);
+      const response = await this.invoke(prompt);
 
       return response;
     } catch (err) {
@@ -168,7 +174,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     );
 
     try {
-      const response = await this.invoke(prompt, true);
+      const response = await this.invoke(prompt, { json: true });
       return parseJsonResponse<Record<string, any>>(response);
     } catch (error) {
       console.error('Failed to extract GitHub inputs with Codex:', error);

--- a/packages/cli/src/lib/agents/gemini.ts
+++ b/packages/cli/src/lib/agents/gemini.ts
@@ -3,6 +3,7 @@ import {
   AIAgentTool,
   InvokeAIAgentError,
   MissingAIAgentError,
+  type InvokeOptions,
 } from './index.js';
 import { PromptBuilder, IPromptTask } from '../prompts/index.js';
 import { parseJsonResponse } from '../../utils/json-parser.js';
@@ -41,13 +42,14 @@ class GeminiAI implements AIAgentTool {
     }
   }
 
-  async invoke(
-    prompt: string,
-    json: boolean = false,
-    cwd?: string
-  ): Promise<string> {
+  async invoke(prompt: string, options: InvokeOptions = {}): Promise<string> {
+    const { json = false, cwd, model } = options;
     // Do not add -p, it's deprecated
     const geminiArgs: string[] = [];
+
+    if (model) {
+      geminiArgs.push('--model', model);
+    }
 
     if (json) {
       // Gemini does not have any way to force the JSON output at CLI level.
@@ -79,7 +81,10 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     );
 
     try {
-      const response = await this.invoke(prompt, true, projectPath);
+      const response = await this.invoke(prompt, {
+        json: true,
+        cwd: projectPath,
+      });
       return parseJsonResponse<IPromptTask>(response);
     } catch (error) {
       console.error('Failed to expand task with Gemini:', error);
@@ -101,7 +106,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     );
 
     try {
-      const response = await this.invoke(prompt, true);
+      const response = await this.invoke(prompt, { json: true });
       return parseJsonResponse<IPromptTask>(response);
     } catch (error) {
       console.error(
@@ -125,7 +130,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
         recentCommits,
         summaries
       );
-      const response = await this.invoke(prompt, false);
+      const response = await this.invoke(prompt);
 
       if (!response) {
         return null;
@@ -152,7 +157,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
         diffContext,
         conflictedContent
       );
-      const response = await this.invoke(prompt, false);
+      const response = await this.invoke(prompt);
 
       return response;
     } catch (err) {
@@ -170,7 +175,7 @@ You MUST output a valid JSON string as an output. Just output the JSON string an
     );
 
     try {
-      const response = await this.invoke(prompt, true);
+      const response = await this.invoke(prompt, { json: true });
       return parseJsonResponse<Record<string, any>>(response);
     } catch (error) {
       console.error('Failed to extract GitHub inputs with Gemini:', error);

--- a/packages/cli/src/lib/agents/index.ts
+++ b/packages/cli/src/lib/agents/index.ts
@@ -19,9 +19,15 @@ export const findKeychainCredentials = (key: string): string => {
   return result.stdout?.toString() || '';
 };
 
+export interface InvokeOptions {
+  json?: boolean;
+  cwd?: string;
+  model?: string;
+}
+
 export interface AIAgentTool {
   // Invoke the CLI tool using the SDK / direct mode with the given prompt
-  invoke(prompt: string, json: boolean, cwd?: string): Promise<string>;
+  invoke(prompt: string, options?: InvokeOptions): Promise<string>;
 
   // Check if the current AI agent is available
   // It will throw an exception in other case


### PR DESCRIPTION
Refactor `AIAgentTool.invoke()` to accept an `InvokeOptions` object instead of positional `json` and `cwd` parameters. This improves readability at call sites and enables passing a `model` option to the underlying CLI tools via `--model`.

Previously, model selection stored in task metadata was never forwarded to the actual agent CLI invocation. With this change, each agent now supports an optional `model` field that gets passed as `--model <model>` to the respective CLI tool.

## Changes

- Added `InvokeOptions` interface (`json`, `cwd`, `model`) to `packages/cli/src/lib/agents/index.ts`
- Updated `AIAgentTool.invoke` signature from `(prompt, json, cwd?)` to `(prompt, options?)`
- Updated all 7 agent implementations (Claude, Codex, Copilot, Cursor, Gemini, OpenCode, Qwen) to destructure the options object and push `--model` to CLI args when provided
- Updated all internal `invoke` call sites across agent classes to use the new object syntax

## Notes

No external callers needed changes since commands only use higher-level methods (`expandTask`, `generateCommitMessage`, etc.) and never call `invoke` directly.