### PR TITLE
feat: migrate Qwen agent to ACP mode

### DIFF
--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -356,7 +356,7 @@ export const runCommand = async (
 
       // Temporarily ACP usage decision during ACP migration process:
       // force Claude, Copilot, and OpenCode to always use ACP mode
-      const acpEnabledTools = ['claude', 'copilot', 'opencode'];
+      const acpEnabledTools = ['claude', 'copilot', 'opencode', 'qwen'];
       const useACPMode = acpEnabledTools.includes(tool.toLowerCase());
 
       if (useACPMode) {

--- a/packages/agent/src/lib/agents/base.ts
+++ b/packages/agent/src/lib/agents/base.ts
@@ -14,6 +14,10 @@ export abstract class BaseAgent implements Agent {
   version: string;
   model?: string;
 
+  get acpCommand(): string {
+    return this.binary;
+  }
+
   constructor(version: string = 'latest', model?: string) {
     this.version = version;
     this.model = model;

--- a/packages/agent/src/lib/agents/claude.ts
+++ b/packages/agent/src/lib/agents/claude.ts
@@ -176,16 +176,12 @@ export class ClaudeAgent extends BaseAgent {
     }
   }
 
+  override get acpCommand(): string {
+    return 'npx';
+  }
+
   toolArguments(): string[] {
-    const args = ['--dangerously-skip-permissions', '--output-format', 'json'];
-    if (this.model) {
-      args.push('--model', this.model);
-    }
-    if (VERBOSE) {
-      args.push('--verbose');
-    }
-    args.push('-p');
-    return args;
+    return ['-y', '@zed-industries/claude-code-acp'];
   }
 
   toolInteractiveArguments(

--- a/packages/agent/src/lib/agents/copilot.ts
+++ b/packages/agent/src/lib/agents/copilot.ts
@@ -161,14 +161,13 @@ export class CopilotAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    const args = ['--allow-all-tools', '--silent'];
+    const args = ['--acp', '--allow-all-tools', '--silent'];
     if (this.model) {
       args.push('--model', this.model);
     }
     if (VERBOSE) {
       args.push('--log-level', 'all');
     }
-    args.push('-p');
     return args;
   }
 

--- a/packages/agent/src/lib/agents/opencode.ts
+++ b/packages/agent/src/lib/agents/opencode.ts
@@ -190,7 +190,7 @@ export class OpenCodeAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    const args = ['run', '--format', 'json'];
+    const args = ['acp', '--format', 'json'];
     if (this.model) {
       args.push('--model', this.model);
     }

--- a/packages/agent/src/lib/agents/qwen.ts
+++ b/packages/agent/src/lib/agents/qwen.ts
@@ -121,14 +121,13 @@ export class QwenAgent extends BaseAgent {
   }
 
   toolArguments(): string[] {
-    const args = ['--yolo'];
+    const args = ['--acp', '--include-directories', '/', '--yolo'];
     if (this.model) {
       args.push('--model', this.model);
     }
     if (VERBOSE) {
       args.push('--debug');
     }
-    args.push('-p');
     return args;
   }
 

--- a/packages/agent/src/lib/agents/types.ts
+++ b/packages/agent/src/lib/agents/types.ts
@@ -29,6 +29,7 @@ export interface AgentErrorRecoveryContext {
 export interface Agent {
   name: string;
   binary: string;
+  acpCommand: string;
   version: string;
 
   getRequiredCredentials(): AgentCredentialFile[];

--- a/packages/agent/src/lib/runner.ts
+++ b/packages/agent/src/lib/runner.ts
@@ -722,7 +722,7 @@ export class Runner {
         instructions += `- **${output.name}**: ${output.description}\n`;
         instructions += `  - Create this file in the current working directory\n`;
 
-        if (this.tool == 'gemini' || this.tool == 'qwen') {
+        if (this.tool == 'gemini') {
           // Gemini has difficulties calling its own tools
           instructions += `  - When creating the file, call the write_file tool using an absolute path based on current directory. THIS IS MANDATORY\n`;
         }


### PR DESCRIPTION
Migrate the Qwen agent to use the Agent Client Protocol (ACP), bringing it in line with Claude, Copilot, and OpenCode. As part of this change, the ACP spawn configuration is moved from a centralized switch/case in `ACPRunner` into each agent's own class, making it easier to add or modify ACP support per agent.

## Changes

- Added Qwen to the list of ACP-enabled tools in the run command
- Introduced an `acpCommand` property on the `Agent` interface (defaults to `binary` in `BaseAgent`), allowing agents to override the command used to spawn their ACP server
- Removed the hardcoded `getACPSpawnCommand` function from `ACPRunner` — it now uses `createAgent()` and delegates to each agent's `acpCommand` and `toolArguments()`
- Updated `toolArguments()` across all agents to return ACP-specific flags:
  - **Claude**: overrides `acpCommand` to `npx` with `@zed-industries/claude-code-acp`
  - **Copilot**: adds `--acp` flag
  - **OpenCode**: switches subcommand from `run` to `acp`
  - **Qwen**: adds `--acp --include-directories /` flags
- Added a workaround in `ACPClient` for ACP servers that issue a `read_text_file` before every `write_text_file` — returns empty content for non-existent files instead of failing with ENOENT
- Removed the Qwen-specific `write_file` instruction workaround from `Runner`, as it is no longer needed under ACP

## Notes

The `toolArguments()` methods now serve double duty: they return ACP-mode arguments when invoked from `ACPRunner`, while each agent still retains its own interactive/non-ACP argument methods separately. This is a transitional state during the broader ACP migration.

Related: https://github.com/endorhq/rover/issues/405