### PR TITLE
feat: add cacheFiles support for sandbox cache invalidation

### DIFF
--- a/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
+++ b/packages/cli/src/lib/sandbox/__tests__/container-image-cache.test.ts
@@ -28,6 +28,7 @@ function makeInputs(overrides: Partial<SetupHashInputs> = {}): SetupHashInputs {
     agent: 'claude',
     roverVersion: '1.0.0',
     initScriptContent: '',
+    cacheFilesContent: '',
     mcps: [],
     ...overrides,
   };
@@ -88,6 +89,23 @@ describe('computeSetupHash', () => {
       makeInputs({ initScriptContent: 'apt-get install -y vim' })
     );
     expect(a).not.toBe(b);
+  });
+
+  it('changes when cacheFilesContent changes', () => {
+    const a = computeSetupHash(makeInputs({ cacheFilesContent: '' }));
+    const b = computeSetupHash(
+      makeInputs({
+        cacheFilesContent:
+          'requirements.txt\0flask==2.0\0package-lock.json\0{}',
+      })
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('produces same hash when cacheFilesContent is empty (backward compat)', () => {
+    const a = computeSetupHash(makeInputs());
+    const b = computeSetupHash(makeInputs({ cacheFilesContent: '' }));
+    expect(a).toBe(b);
   });
 
   it('changes when mcps change', () => {

--- a/packages/core/src/files/project-config.ts
+++ b/packages/core/src/files/project-config.ts
@@ -272,6 +272,9 @@ export class ProjectConfigManager {
   get network(): NetworkConfig | undefined {
     return this.data.sandbox?.network;
   }
+  get cacheFiles(): string[] | undefined {
+    return this.data.sandbox?.cacheFiles;
+  }
   get excludePatterns(): string[] | undefined {
     return this.data.excludePatterns;
   }

--- a/packages/schemas/src/project-config/schema.ts
+++ b/packages/schemas/src/project-config/schema.ts
@@ -106,6 +106,8 @@ export const SandboxConfigSchema = z.object({
   extraArgs: z.union([z.string(), z.array(z.string())]).optional(),
   /** Network filtering configuration */
   network: NetworkConfigSchema.optional(),
+  /** Files whose contents are included in the cache hash for invalidation */
+  cacheFiles: z.array(z.string()).optional(),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add `sandbox.cacheFiles` field to the project config schema (`rover.json`) that accepts an array of file paths
- Include the contents of specified files in the container cache hash computation, so changes to dependency files (e.g. `requirements.txt`, `package-lock.json`) automatically invalidate the cached sandbox image
- Add `cacheFiles` getter to `ProjectConfigManager` and unit tests for hash behavior

## Test plan
- [x] Unit tests pass (36 container-image-cache tests, 418 total)
- [x] Lightweight hash verification: changing file content produces different hash, restoring produces same hash
- [x] Full E2E via `rover task`: confirmed different `rover-cache:<tag>` images created for different file contents, and existing cache reused when content restored
- [x] Backward compatible: empty/missing `cacheFiles` produces same hash as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)