### PR TITLE
chore: copy agent credentials on run instead of install

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -3,11 +3,7 @@
 import { Command, Argument } from 'commander';
 import { AI_AGENT, setVerbose } from 'rover-core';
 import { runCommand } from './commands/run.js';
-import {
-  DEFAULT_INSTALL_DIRECTORY,
-  DEFAULT_INSTALL_VERSION,
-  installCommand,
-} from './commands/install.js';
+import { DEFAULT_INSTALL_VERSION, installCommand } from './commands/install.js';
 import { addConfigCommands } from './commands/config/index.js';
 import { sessionCommand } from './commands/session.js';
 import { getAgentVersion } from './version.js';
@@ -107,11 +103,6 @@ program
     '--version <version>',
     'Install a specific agent version',
     DEFAULT_INSTALL_VERSION
-  )
-  .option(
-    '--user-dir <directory>',
-    'User directory to copy credentials',
-    DEFAULT_INSTALL_DIRECTORY
   )
   .action(installCommand);
 

--- a/packages/agent/src/commands/install.ts
+++ b/packages/agent/src/commands/install.ts
@@ -6,15 +6,12 @@ import { createAgent } from '../lib/agents/index.js';
 interface InstallCommandOptions {
   // Specific version to install
   version: string;
-  // User directory
-  userDir: string;
 }
 
 interface InstallCommandOutput extends CommandOutput {}
 
 // Default agent version to install
 export const DEFAULT_INSTALL_VERSION = 'latest';
-export const DEFAULT_INSTALL_DIRECTORY = process.env.HOME || '/home/agent';
 
 /**
  * Install an AI Coding Tool and configure the required credentials to run it
@@ -23,7 +20,6 @@ export const installCommand = async (
   agentName: string,
   options: InstallCommandOptions = {
     version: DEFAULT_INSTALL_VERSION,
-    userDir: DEFAULT_INSTALL_DIRECTORY,
   }
 ) => {
   const output: InstallCommandOutput = {
@@ -64,9 +60,6 @@ export const installCommand = async (
 
       // Install the agent
       await agent.install();
-
-      // Copy credentials to home directory (for container usage)
-      await agent.copyCredentials(options.userDir);
 
       console.log(colors.green('\n✓ Installation completed successfully'));
       output.success = true;

--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -361,6 +361,22 @@ export const runCommand = async (
       const tool =
         options.agentTool || workflowManager.defaults?.tool || 'claude';
 
+      // Copy credentials to home directory on every run so that fresh
+      // credentials are available even when the container image was cached
+      // via docker/podman commit during install.
+      const userDir = process.env.HOME || '/home/agent';
+      try {
+        const agent = createAgent(tool);
+        await agent.copyCredentials(userDir);
+        console.log(colors.green('✓ Credentials copied successfully\n'));
+      } catch (err) {
+        console.log(
+          colors.yellow(
+            `Warning: Failed to copy credentials: ${err instanceof Error ? err.message : String(err)}\n`
+          )
+        );
+      }
+
       // ACP usage decision: use ACP mode for agents that support it
       const acpEnabledTools = [
         'claude',

--- a/packages/cli/src/lib/entrypoint.sh
+++ b/packages/cli/src/lib/entrypoint.sh
@@ -10,6 +10,8 @@
 if [[ -z "$\{HOME\}" ]]; then
   export HOME=/home/$(id -u)
 fi
+sudo mkdir -p $HOME
+sudo chown -R $(id -u):$(id -g) $HOME
 
 # Some tools might be installed under /root/local/.bin conditionally
 # depending on the chosen agent and requirements, make this directory

--- a/packages/cli/src/lib/setup.ts
+++ b/packages/cli/src/lib/setup.ts
@@ -306,7 +306,7 @@ ${installScripts.join('\n')}
       agentInstallSection = `# Agent-specific CLI installation and credential setup
 echo -e "\\n📦 Installing Agent CLI and setting up credentials"
 # Pass the environment variables to ensure it loads the right credentials
-sudo -E rover-agent install $AGENT --user-dir $HOME
+sudo -E rover-agent install $AGENT
 # Set the right permissions after installing and moving credentials
 sudo chown -R $(id -u):$(id -g) $HOME
 


### PR DESCRIPTION
Move credential copying from the `install` phase to the `run` phase of the agent lifecycle. This ensures fresh credentials are always available at runtime, even when the container image was cached via `docker`/`podman` commit during install.

Previously, credentials were copied during `rover-agent install` using a `--user-dir` flag. This caused issues when cached container images retained stale credentials from the install step. By deferring the copy to `rover-agent run`, each execution gets the latest mounted credentials.

## Changes

- Moved `agent.copyCredentials()` call from the `install` command to the `run` command, executing it before each agent run
- Removed the `--user-dir` option from the `install` CLI command and its associated `DEFAULT_INSTALL_DIRECTORY` constant
- Updated the container entrypoint script to ensure `$HOME` exists and has correct ownership before the agent runs
- Simplified the `sudo -E rover-agent install` call in the setup script by removing the now-unnecessary `--user-dir` flag

## Notes

The credential copy in `run` includes error handling that logs a warning instead of failing hard, so that runs can still proceed if credentials are already in place or the copy encounters a non-critical issue.