### PR TITLE
chore: gate verbose output behind VERBOSE flag in ACP

### DIFF
--- a/packages/agent/src/lib/acp-runner.ts
+++ b/packages/agent/src/lib/acp-runner.ts
@@ -132,11 +132,13 @@ export class ACPRunner {
       env: process.env,
     });
 
-    // Always forward stderr for debugging (can be seen in docker logs)
+    // Forward stderr for debugging when VERBOSE is enabled
     if (this.agentProcess.stderr) {
       this.agentProcess.stderr.on('data', (chunk: Buffer) => {
-        const text = chunk.toString();
-        console.log(colors.yellow(`[ACP Agent stderr] ${text.trim()}`));
+        if (VERBOSE) {
+          const text = chunk.toString();
+          console.log(colors.yellow(`[ACP Agent stderr] ${text.trim()}`));
+        }
       });
     }
 
@@ -168,17 +170,21 @@ export class ACPRunner {
         },
       };
 
-      console.log(
-        colors.gray('[ACP] Sending initialize request:'),
-        colors.cyan(JSON.stringify(initRequest, null, 2))
-      );
+      if (VERBOSE) {
+        console.log(
+          colors.gray('[ACP] Sending initialize request:'),
+          colors.cyan(JSON.stringify(initRequest, null, 2))
+        );
+      }
 
       const initResult = await this.connection.initialize(initRequest);
 
-      console.log(
-        colors.gray('[ACP] Initialize response:'),
-        colors.cyan(JSON.stringify(initResult, null, 2))
-      );
+      if (VERBOSE) {
+        console.log(
+          colors.gray('[ACP] Initialize response:'),
+          colors.cyan(JSON.stringify(initResult, null, 2))
+        );
+      }
 
       this.isConnectionInitialized = true;
 
@@ -226,17 +232,21 @@ export class ACPRunner {
         mcpServers,
       };
 
-      console.log(
-        colors.gray('[ACP] Sending newSession request:'),
-        colors.cyan(JSON.stringify(sessionRequest, null, 2))
-      );
+      if (VERBOSE) {
+        console.log(
+          colors.gray('[ACP] Sending newSession request:'),
+          colors.cyan(JSON.stringify(sessionRequest, null, 2))
+        );
+      }
 
       const sessionResult = await this.connection.newSession(sessionRequest);
 
-      console.log(
-        colors.gray('[ACP] newSession response:'),
-        colors.cyan(JSON.stringify(sessionResult, null, 2))
-      );
+      if (VERBOSE) {
+        console.log(
+          colors.gray('[ACP] newSession response:'),
+          colors.cyan(JSON.stringify(sessionResult, null, 2))
+        );
+      }
 
       this.sessionId = sessionResult.sessionId;
       this.isSessionCreated = true;
@@ -340,23 +350,27 @@ export class ACPRunner {
         }
       }
 
-      console.log(
-        colors.gray(
-          '[ACP] Sending prompt request (prompt length: ' +
-            prompt.length +
-            ' chars)'
-        )
-      );
+      if (VERBOSE) {
+        console.log(
+          colors.gray(
+            '[ACP] Sending prompt request (prompt length: ' +
+              prompt.length +
+              ' chars)'
+          )
+        );
+      }
 
       const promptResult = await this.connection.prompt({
         sessionId: this.sessionId,
         prompt: promptContent,
       });
 
-      console.log(
-        colors.gray('[ACP] Prompt response:'),
-        colors.cyan(JSON.stringify(promptResult, null, 2))
-      );
+      if (VERBOSE) {
+        console.log(
+          colors.gray('[ACP] Prompt response:'),
+          colors.cyan(JSON.stringify(promptResult, null, 2))
+        );
+      }
 
       // Stop capturing and get the accumulated response
       const response = this.client.stopCapturing();
@@ -503,9 +517,11 @@ export class ACPRunner {
       // Send the prompt via ACP session
       const promptResult = await this.sendPrompt(prompt);
 
-      console.log(
-        colors.gray(`\n✅ Agent completed with: ${promptResult.stopReason}`)
-      );
+      if (VERBOSE) {
+        console.log(
+          colors.gray(`\n✅ Agent completed with: ${promptResult.stopReason}`)
+        );
+      }
 
       // Store common outputs
       outputs.set('raw_output', `Stop reason: ${promptResult.stopReason}`);
@@ -1002,7 +1018,9 @@ export class ACPRunner {
    */
   closeSession(): void {
     if (this.sessionId) {
-      console.log(colors.gray(`🔌 Closing session: ${this.sessionId}`));
+      if (VERBOSE) {
+        console.log(colors.gray(`🔌 Closing session: ${this.sessionId}`));
+      }
       this.sessionId = null;
       this.isSessionCreated = false;
     }
@@ -1013,7 +1031,9 @@ export class ACPRunner {
    */
   close(): void {
     if (this.agentProcess) {
-      console.log(colors.gray('\n🔌 Closing ACP connection...'));
+      if (VERBOSE) {
+        console.log(colors.gray('\n🔌 Closing ACP connection...'));
+      }
       this.agentProcess.kill('SIGTERM');
       this.agentProcess = null;
     }

--- a/packages/agent/src/lib/gemini-or-qwen-acp-client.ts
+++ b/packages/agent/src/lib/gemini-or-qwen-acp-client.ts
@@ -1,5 +1,6 @@
 import type { ReadTextFileResponse } from '@agentclientprotocol/sdk';
 import colors from 'ansi-colors';
+import { VERBOSE } from 'rover-core';
 import { ACPClient } from './acp-client.js';
 
 /**
@@ -14,11 +15,13 @@ export class GeminiOrQwenACPClient extends ACPClient {
   protected override onFileNotFound(
     path: string
   ): Promise<ReadTextFileResponse> {
-    console.log(
-      colors.yellow(
-        `[ACP] readTextFile: Returning empty content for missing file ${path} (Gemini/Qwen)`
-      )
-    );
+    if (VERBOSE) {
+      console.log(
+        colors.yellow(
+          `[ACP] readTextFile: Returning empty content for missing file ${path} (Gemini/Qwen)`
+        )
+      );
+    }
     return Promise.resolve({ content: '' });
   }
 }


### PR DESCRIPTION
Gate all ACP debug logging behind the `VERBOSE` flag so that non-verbose runs produce cleaner output. Previously, many `console.log` calls in the ACP client and runner were always emitted regardless of verbosity settings, making normal agent output noisy with internal protocol details.

## Changes

- Wrap all `[ACP]` debug log statements in `acp-client.ts` behind `if (VERBOSE)` checks — covering `requestPermission`, `sessionUpdate`, `writeTextFile`, `readTextFile`, `createTerminal`, `terminalOutput`, `releaseTerminal`, `waitForTerminalExit`, `killTerminal`, `extMethod`, and `extNotification`
- Gate `[ACP]` protocol logs in `acp-runner.ts` for `initialize`, `newSession`, `prompt`, session close, and agent process stderr forwarding
- Gate the file-not-found log in `gemini-or-qwen-acp-client.ts` and add the missing `VERBOSE` import from `rover-core`
- Retain unconditional logging only for actual errors (e.g. write failures, read failures, unknown terminal IDs)