### PR TITLE
feat(cli): detect piped stdout and output content-only for inspect

### DIFF
--- a/packages/cli/src/commands/__tests__/inspect.test.ts
+++ b/packages/cli/src/commands/__tests__/inspect.test.ts
@@ -9,6 +9,7 @@ import {
   IterationManager,
 } from 'rover-core';
 import { inspectCommand } from '../inspect.js';
+import { isStdoutTTY } from '../../utils/stdout.js';
 
 // Store testDir for context mock
 let testDir: string;
@@ -47,6 +48,11 @@ vi.mock('../../lib/telemetry.js', () => ({
 // Mock display utilities to suppress output during tests
 vi.mock('../../utils/display.js', () => ({
   showTips: vi.fn(),
+}));
+
+// Mock stdout TTY detection so we can test piped vs interactive behavior
+vi.mock('../../utils/stdout.js', () => ({
+  isStdoutTTY: vi.fn(() => true),
 }));
 
 describe('inspect command', () => {
@@ -349,6 +355,60 @@ describe('inspect command', () => {
       const output = capturedOutput.join('\n');
       expect(output).toContain('Human Readable Task');
       expect(output).toContain('Details');
+    });
+  });
+
+  describe('Piped stdout (content-only output)', () => {
+    it('should output only raw file content when stdout is piped', async () => {
+      createTestTask(1, 'Piped Task');
+      vi.mocked(isStdoutTTY).mockReturnValue(false);
+
+      await inspectCommand('1');
+
+      const output = capturedOutput.join('\n');
+      // Should contain the raw file content (summary.md from createTestTask)
+      expect(output).toContain('# Test Summary');
+      // Should not contain decorated output
+      expect(output).not.toContain('Details');
+      expect(output).not.toContain('Workspace');
+      expect(output).not.toContain('Workflow Output');
+      // Should not contain box-drawing characters from showFile
+      expect(output).not.toMatch(/┌|└|│/);
+
+      vi.mocked(isStdoutTTY).mockReturnValue(true);
+    });
+
+    it('should output nothing when stdout is piped and task has no iteration files', async () => {
+      const taskPath = join(testDir, '.rover', 'tasks', '2');
+      const task = TaskDescriptionManager.create(taskPath, {
+        id: 2,
+        title: 'Empty Task',
+        description: 'No iterations',
+        inputs: new Map(),
+        workflowName: 'swe',
+      });
+      const worktreePath = join('.rover', 'tasks', '2', 'workspace');
+      launchSync('git', [
+        'worktree',
+        'add',
+        worktreePath,
+        '-b',
+        'rover-task-2',
+      ]);
+      task.setWorkspace(join(testDir, worktreePath), 'rover-task-2');
+      task.markInProgress();
+      task.markCompleted();
+      // No iteration directory with markdown files
+
+      vi.mocked(isStdoutTTY).mockReturnValue(false);
+
+      await inspectCommand('2');
+
+      const output = capturedOutput.join('\n');
+      expect(output).not.toContain('Details');
+      expect(output).not.toContain('Workspace');
+
+      vi.mocked(isStdoutTTY).mockReturnValue(true);
     });
   });
 });

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -20,6 +20,7 @@ import {
   requireProjectContext,
 } from '../lib/context.js';
 import { exitWithError, exitWithSuccess } from '../utils/exit.js';
+import { isStdoutTTY } from '../utils/stdout.js';
 import type {
   FileChangeStat,
   RawFileOutput,
@@ -269,133 +270,147 @@ const inspectCommand = async (
       await exitWithSuccess(null, jsonOutput, { telemetry });
       return;
     } else {
-      // Format status with user-friendly names
-      const formattedStatus = formatTaskStatus(task.status);
-
-      // Status color
-      const statusColorFunc = statusColor(task.status);
-
-      showTitle('Details');
-
-      const properties: Record<string, string> = {
-        ID: `${task.id.toString()} (${colors.gray(task.uuid)})`,
-        Title: task.title,
-        Status: statusColorFunc(formattedStatus),
-        Agent: task.agent
-          ? formatAgentWithModel(task.agent as any, task.agentModel)
-          : '-',
-        Workflow: task.workflowName,
-        'Created At': new Date(task.createdAt).toLocaleString(),
-      };
-
-      // Show task source if available (e.g., GitHub issue, etc.)
-      if (task.source?.url) {
-        const sourceLabel =
-          task.source.type === 'github' ? 'GitHub Issue' : 'Source';
-        properties[sourceLabel] = colors.cyan(task.source.url);
-      }
-
-      if (task.completedAt) {
-        properties['Completed At'] = new Date(
-          task.completedAt
-        ).toLocaleString();
-      } else if (task.failedAt) {
-        properties['Failed At'] = new Date(task.failedAt).toLocaleString();
-      }
-
-      // Show error if failed
-      if (task.error) {
-        properties['Error'] = colors.red(task.error);
-      }
-
-      showProperties(properties);
-
-      // Workspace information
-      showTitle('Workspace');
-
-      const workspaceProps: Record<string, string> = {
-        'Branch Name': task.branchName,
-        'Git Workspace path': task.worktreePath,
-      };
-
-      showProperties(workspaceProps);
-
-      // Workflow files
       const discoveredFiles = iteration.listMarkdownFiles();
 
-      if (discoveredFiles.length > 0) {
-        showTitle(
-          `Workflow Output ${colors.gray(`| Iteration ${iterationNumber}/${task.iterations}`)}`
-        );
-        showList(discoveredFiles);
-
-        // Show the summary file by default only when it's available
-        const hasSummary = discoveredFiles.includes(DEFAULT_FILE_CONTENTS);
-        const fileFilter = options.file || [
-          hasSummary
-            ? DEFAULT_FILE_CONTENTS
-            : discoveredFiles[discoveredFiles.length - 1],
-        ];
-
-        const iterationFileContents = iteration.getMarkdownFiles(fileFilter);
-        if (iterationFileContents.size === 0) {
-          console.log(
-            colors.gray(
-              `\nNo content for the ${fileFilter.join(', ')} files found for iteration ${iterationNumber}.`
-            )
-          );
-        } else {
-          console.log();
-          iterationFileContents.forEach((contents, file) => {
-            showFile(file, contents.trim());
+      if (!isStdoutTTY()) {
+        // Piped stdout: output only raw file content, no decorations
+        if (discoveredFiles.length > 0) {
+          const hasSummary = discoveredFiles.includes(DEFAULT_FILE_CONTENTS);
+          const fileFilter = options.file || [
+            hasSummary
+              ? DEFAULT_FILE_CONTENTS
+              : discoveredFiles[discoveredFiles.length - 1],
+          ];
+          const iterationFileContents = iteration.getMarkdownFiles(fileFilter);
+          iterationFileContents.forEach(contents => {
+            console.log(contents.trim());
           });
         }
-      }
+      } else {
+        // Interactive TTY: Format status with user-friendly names
+        const formattedStatus = formatTaskStatus(task.status);
+        // Status color
+        const statusColorFunc = statusColor(task.status);
 
-      // Show file changes only if task is not in an active state
-      if (!task.isActive()) {
-        const git = new Git({ cwd: project.path });
-        const stats = await git.diffStats({
-          worktreePath: task.worktreePath,
-          includeUntracked: true,
-        });
+        showTitle('Details');
 
-        const statFiles = stats.files.map(fileStat => {
-          const insertions =
-            fileStat.insertions > 0
-              ? colors.green(`+${fileStat.insertions}`)
-              : '';
-          const deletions =
-            fileStat.deletions > 0 ? colors.red(`-${fileStat.deletions}`) : '';
-          return `${insertions} ${deletions} ${colors.cyan(fileStat.path)}`;
-        });
+        const properties: Record<string, string> = {
+          ID: `${task.id.toString()} (${colors.gray(task.uuid)})`,
+          Title: task.title,
+          Status: statusColorFunc(formattedStatus),
+          Agent: task.agent
+            ? formatAgentWithModel(task.agent as any, task.agentModel)
+            : '-',
+          Workflow: task.workflowName,
+          'Created At': new Date(task.createdAt).toLocaleString(),
+        };
 
-        showTitle('File Changes');
-        showList(statFiles);
-      }
+        // Show task source if available (e.g., GitHub issue, etc.)
+        if (task.source?.url) {
+          const sourceLabel =
+            task.source.type === 'github' ? 'GitHub Issue' : 'Source';
+          properties[sourceLabel] = colors.cyan(task.source.url);
+        }
 
-      const tips = [];
+        if (task.completedAt) {
+          properties['Completed At'] = new Date(
+            task.completedAt
+          ).toLocaleString();
+        } else if (task.failedAt) {
+          properties['Failed At'] = new Date(task.failedAt).toLocaleString();
+        }
 
-      if (task.status === 'NEW' || task.status === 'FAILED') {
-        tips.push(
-          'Use ' + colors.cyan(`rover restart ${taskId}`) + ' to retry it'
-        );
-      } else if (options.file == null && discoveredFiles.length > 0) {
-        tips.push(
+        // Show error if failed
+        if (task.error) {
+          properties['Error'] = colors.red(task.error);
+        }
+
+        showProperties(properties);
+
+        // Workspace information
+        showTitle('Workspace');
+
+        const workspaceProps: Record<string, string> = {
+          'Branch Name': task.branchName,
+          'Git Workspace path': task.worktreePath,
+        };
+
+        showProperties(workspaceProps);
+
+        if (discoveredFiles.length > 0) {
+          showTitle(
+            `Workflow Output ${colors.gray(`| Iteration ${iterationNumber}/${task.iterations}`)}`
+          );
+          showList(discoveredFiles);
+
+          // Show the summary file by default only when it's available
+          const hasSummary = discoveredFiles.includes(DEFAULT_FILE_CONTENTS);
+          const fileFilter = options.file || [
+            hasSummary
+              ? DEFAULT_FILE_CONTENTS
+              : discoveredFiles[discoveredFiles.length - 1],
+          ];
+
+          const iterationFileContents = iteration.getMarkdownFiles(fileFilter);
+          if (iterationFileContents.size === 0) {
+            console.log(
+              colors.gray(
+                `\nNo content for the ${fileFilter.join(', ')} files found for iteration ${iterationNumber}.`
+              )
+            );
+          } else {
+            console.log();
+            iterationFileContents.forEach((contents, file) => {
+              showFile(file, contents.trim());
+            });
+          }
+        }
+
+        // Show file changes only if task is not in an active state
+        if (!task.isActive()) {
+          const git = new Git({ cwd: project.path });
+          const stats = await git.diffStats({
+            worktreePath: task.worktreePath,
+            includeUntracked: true,
+          });
+
+          const statFiles = stats.files.map(fileStat => {
+            const insertions =
+              fileStat.insertions > 0
+                ? colors.green(`+${fileStat.insertions}`)
+                : '';
+            const deletions =
+              fileStat.deletions > 0 ? colors.red(`-${fileStat.deletions}`) : '';
+            return `${insertions} ${deletions} ${colors.cyan(fileStat.path)}`;
+          });
+
+          showTitle('File Changes');
+          showList(statFiles);
+        }
+
+        const tips = [];
+
+        if (task.status === 'NEW' || task.status === 'FAILED') {
+          tips.push(
+            'Use ' + colors.cyan(`rover restart ${taskId}`) + ' to retry it'
+          );
+        } else if (options.file == null && discoveredFiles.length > 0) {
+          tips.push(
+            'Use ' +
+              colors.cyan(
+                `rover inspect ${taskId} --file ${discoveredFiles[0]}`
+              ) +
+              ' to read its content'
+          );
+        }
+
+        showTips([
+          ...tips,
           'Use ' +
-            colors.cyan(
-              `rover inspect ${taskId} --file ${discoveredFiles[0]}`
-            ) +
-            ' to read its content'
-        );
+            colors.cyan(`rover iterate ${taskId}`) +
+            ' to start a new agent iteration on this task',
+        ]);
       }
-
-      showTips([
-        ...tips,
-        'Use ' +
-          colors.cyan(`rover iterate ${taskId}`) +
-          ' to start a new agent iteration on this task',
-      ]);
     }
 
     await exitWithSuccess(null, { success: true }, { telemetry });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -40,6 +40,7 @@ import {
 } from './lib/context.js';
 import { showRoverHeader } from 'rover-core/src/display/header.js';
 import { getUserAIAgent } from './lib/agents/index.js';
+import { isStdoutTTY } from './utils/stdout.js';
 import type { CommandDefinition } from './types.js';
 
 // Registry of all commands for metadata lookup
@@ -207,8 +208,8 @@ export function createProgram(
           agentName = agent.toString();
         }
 
-        if (isJsonMode() || commandName === 'mcp') {
-          // Do not print anything for JSON or MCP mode
+        if (isJsonMode() || commandName === 'mcp' || !isStdoutTTY()) {
+          // Do not print anything for JSON, MCP, or when stdout is piped
           return;
         }
 

--- a/packages/cli/src/utils/stdout.ts
+++ b/packages/cli/src/utils/stdout.ts
@@ -1,0 +1,19 @@
+/**
+ * Utility functions for stdout / TTY detection
+ */
+
+/**
+ * Check if stdout is a TTY (interactive terminal).
+ * When false, stdout is piped or redirected (e.g. to another process or file).
+ */
+export const isStdoutTTY = (): boolean => {
+  return process.stdout.isTTY === true;
+};
+
+/**
+ * Check if stdout is being piped or redirected.
+ * Use this when output should be content-only (no banners, boxes, or decorations).
+ */
+export const isStdoutPiped = (): boolean => {
+  return !isStdoutTTY();
+};


### PR DESCRIPTION
When stdout is piped or redirected (e.g. `rover inspect 10 | cat` or `rover inspect --file=docs.md 6 > out.txt`), the CLI now outputs only the raw content: no Rover header, no Details/Workspace sections, no box around file content, no tips. In an interactive terminal, behavior is unchanged (full formatted output).

Closes #456.

## Changes

- Added `packages/cli/src/utils/stdout.ts` with `isStdoutTTY()` and `isStdoutPiped()` for stdout TTY detection
- Skip Rover header in the program preAction hook when `!isStdoutTTY()` (in addition to JSON and MCP mode)
- In `inspect`, when stdout is not a TTY: output only the raw content of the requested or default iteration file(s) via `console.log`; no `showTitle`, `showProperties`, `showList`, `showFile`, or `showTips`
- Added unit tests that mock `isStdoutTTY` to assert content-only output when piped and no "Details" / "Workspace" / box-drawing characters

## Notes

- `--json` and `--raw-file` behavior is unchanged
- To verify: run `node packages/cli/dist/index.mjs inspect <taskId> | cat` after `pnpm build` to ensure the local CLI is used (global `rover` may be an older version)