### PR TITLE
feat: support multiple parallel ACP sessions per connection

### DIFF
--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -449,17 +449,16 @@ export const runCommand = async (
           _stepIndex: number,
           stepsOutput: Map<string, Map<string, string>>
         ): Promise<StepResult> => {
+          const sessionId = await acpRunner.createSession();
           try {
-            await acpRunner.createSession();
-
             // Inject previous step outputs before running
             for (const [prevStepId, prevOutputs] of stepsOutput.entries()) {
               acpRunner.stepsOutput.set(prevStepId, prevOutputs);
             }
 
-            return await acpRunner.runStep(step.id);
+            return await acpRunner.runStep(sessionId, step.id);
           } finally {
-            acpRunner.closeSession();
+            acpRunner.closeSession(sessionId);
           }
         },
       };

--- a/packages/agent/src/lib/acp-client.ts
+++ b/packages/agent/src/lib/acp-client.ts
@@ -59,31 +59,50 @@ interface TerminalState {
 
 const terminals = new Map<string, TerminalState>();
 
-export class ACPClient implements Client {
-  private capturedMessages: string = '';
-  private isCapturing: boolean = false;
+interface SessionCaptureState {
+  capturedMessages: string;
+  isCapturing: boolean;
+  cumulativeCostAmount: number;
+  cumulativeCostCurrency: string;
+  costAtCaptureStart: number;
+}
 
-  // Cost tracking: cumulative cost reported by the agent via usage_update events
-  private cumulativeCostAmount: number = 0;
-  private cumulativeCostCurrency: string = 'USD';
-  private costAtCaptureStart: number = 0;
+export class ACPClient implements Client {
+  private sessions = new Map<string, SessionCaptureState>();
+
+  private getOrCreateSession(sessionId: string): SessionCaptureState {
+    let session = this.sessions.get(sessionId);
+    if (!session) {
+      session = {
+        capturedMessages: '',
+        isCapturing: false,
+        cumulativeCostAmount: 0,
+        cumulativeCostCurrency: 'USD',
+        costAtCaptureStart: 0,
+      };
+      this.sessions.set(sessionId, session);
+    }
+    return session;
+  }
 
   /**
    * Start capturing agent messages from session updates
    */
-  startCapturing(): void {
-    this.capturedMessages = '';
-    this.isCapturing = true;
-    this.costAtCaptureStart = this.cumulativeCostAmount;
+  startCapturing(sessionId: string): void {
+    const session = this.getOrCreateSession(sessionId);
+    session.capturedMessages = '';
+    session.isCapturing = true;
+    session.costAtCaptureStart = session.cumulativeCostAmount;
   }
 
   /**
    * Stop capturing and return accumulated messages
    */
-  stopCapturing(): string {
-    this.isCapturing = false;
-    const messages = this.capturedMessages;
-    this.capturedMessages = '';
+  stopCapturing(sessionId: string): string {
+    const session = this.getOrCreateSession(sessionId);
+    session.isCapturing = false;
+    const messages = session.capturedMessages;
+    session.capturedMessages = '';
     return messages;
   }
 
@@ -92,11 +111,19 @@ export class ACPClient implements Client {
    * startCapturing and stopCapturing). Returns the delta in the
    * cumulative cost reported by the agent via usage_update events.
    */
-  getLastPromptCost(): { amount: number; currency: string } {
+  getLastPromptCost(sessionId: string): { amount: number; currency: string } {
+    const session = this.getOrCreateSession(sessionId);
     return {
-      amount: this.cumulativeCostAmount - this.costAtCaptureStart,
-      currency: this.cumulativeCostCurrency,
+      amount: session.cumulativeCostAmount - session.costAtCaptureStart,
+      currency: session.cumulativeCostCurrency,
     };
+  }
+
+  /**
+   * Remove session capture state (cleanup after session close)
+   */
+  removeSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
   }
 
   requestPermission(
@@ -140,6 +167,7 @@ export class ACPClient implements Client {
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
     const update = params.update;
+    const session = this.getOrCreateSession(params.sessionId);
 
     if (VERBOSE) {
       console.log(
@@ -152,8 +180,8 @@ export class ACPClient implements Client {
       case 'agent_message_chunk':
         if (update.content.type === 'text') {
           // Capture agent messages when capturing is enabled
-          if (this.isCapturing) {
-            this.capturedMessages += update.content.text;
+          if (session.isCapturing) {
+            session.capturedMessages += update.content.text;
           }
           if (VERBOSE) {
             process.stdout.write(update.content.text);
@@ -204,15 +232,15 @@ export class ACPClient implements Client {
           }
         }
 
-        if (this.isCapturing && update.content.type === 'text') {
-          this.capturedMessages += `[THINKING] ${update.content.text}`;
+        if (session.isCapturing && update.content.type === 'text') {
+          session.capturedMessages += `[THINKING] ${update.content.text}`;
         }
         break;
       case 'usage_update':
         // Track cumulative cost reported by the agent
         if (update.cost) {
-          this.cumulativeCostAmount = update.cost.amount;
-          this.cumulativeCostCurrency = update.cost.currency;
+          session.cumulativeCostAmount = update.cost.amount;
+          session.cumulativeCostCurrency = update.cost.currency;
         }
         break;
       case 'available_commands_update':

--- a/packages/agent/src/lib/acp-runner.ts
+++ b/packages/agent/src/lib/acp-runner.ts
@@ -81,9 +81,8 @@ export class ACPRunner {
   private agentProcess: ChildProcess | null = null;
   private connection: ClientSideConnection | null = null;
   private client: ACPClient | null = null;
-  private sessionId: string | null = null;
+  private activeSessions = new Set<string>();
   private isConnectionInitialized: boolean = false;
-  private isSessionCreated: boolean = false;
   private tool: string;
 
   constructor(config: ACPRunnerConfig) {
@@ -222,12 +221,6 @@ export class ACPRunner {
       );
     }
 
-    if (this.isSessionCreated) {
-      throw new Error(
-        'Session already created. Use the existing session or close it first.'
-      );
-    }
-
     try {
       // Create a new session
       const sessionRequest = {
@@ -251,12 +244,12 @@ export class ACPRunner {
         );
       }
 
-      this.sessionId = sessionResult.sessionId;
-      this.isSessionCreated = true;
+      const sessionId = sessionResult.sessionId;
+      this.activeSessions.add(sessionId);
 
-      console.log(colors.gray(`📝 Created session: ${this.sessionId}`));
+      console.log(colors.gray(`📝 Created session: ${sessionId}`));
 
-      return sessionResult.sessionId;
+      return sessionId;
     } catch (error) {
       console.log(
         colors.red('[ACP] newSession failed:'),
@@ -273,6 +266,7 @@ export class ACPRunner {
    * Supports text, images (base64 or file:// URIs), and embedded resources.
    */
   async sendPrompt(
+    sessionId: string,
     prompt: string,
     options?: {
       /** Image attachments (base64 data or file:// URIs) */
@@ -301,8 +295,10 @@ export class ACPRunner {
       );
     }
 
-    if (!this.isSessionCreated || !this.sessionId) {
-      throw new Error('No active session. Call createSession() first.');
+    if (!this.activeSessions.has(sessionId)) {
+      throw new Error(
+        `Session '${sessionId}' not found. Call createSession() first.`
+      );
     }
 
     if (!this.client) {
@@ -311,7 +307,7 @@ export class ACPRunner {
 
     try {
       // Start capturing agent messages
-      this.client.startCapturing();
+      this.client.startCapturing(sessionId);
 
       // Build prompt content array
       const promptContent: ContentBlock[] = [
@@ -369,7 +365,7 @@ export class ACPRunner {
       }
 
       const promptResult = await this.connection.prompt({
-        sessionId: this.sessionId,
+        sessionId,
         prompt: promptContent,
       });
 
@@ -381,7 +377,7 @@ export class ACPRunner {
       }
 
       // Stop capturing and get the accumulated response
-      const response = this.client.stopCapturing();
+      const response = this.client.stopCapturing(sessionId);
 
       // Extract usage stats from the ACP response
       const tokens = promptResult.usage
@@ -392,7 +388,7 @@ export class ACPRunner {
         : undefined;
 
       // Get per-prompt cost delta from the client's tracked usage_update events
-      const promptCost = this.client.getLastPromptCost();
+      const promptCost = this.client.getLastPromptCost(sessionId);
       const cost = promptCost.amount > 0 ? promptCost.amount : undefined;
 
       return { stopReason: promptResult.stopReason, response, tokens, cost };
@@ -402,7 +398,7 @@ export class ACPRunner {
         colors.red(formatError(error))
       );
       // Stop capturing on error too
-      this.client.stopCapturing();
+      this.client.stopCapturing(sessionId);
       throw new Error(`Failed to send prompt: ${formatError(error)}`);
     }
   }
@@ -413,20 +409,22 @@ export class ACPRunner {
    *
    * Allows changing the AI model used for subsequent prompts in the session.
    */
-  async setModel(modelId: string): Promise<void> {
+  async setModel(sessionId: string, modelId: string): Promise<void> {
     if (!this.isConnectionInitialized || !this.connection) {
       throw new Error(
         'Connection not initialized. Call initializeConnection() first.'
       );
     }
 
-    if (!this.isSessionCreated || !this.sessionId) {
-      throw new Error('No active session. Call createSession() first.');
+    if (!this.activeSessions.has(sessionId)) {
+      throw new Error(
+        `Session '${sessionId}' not found. Call createSession() first.`
+      );
     }
 
     try {
       await this.connection.unstable_setSessionModel({
-        sessionId: this.sessionId,
+        sessionId,
         modelId,
       });
 
@@ -442,24 +440,26 @@ export class ACPRunner {
    *
    * Aborts any running language model requests and tool calls.
    */
-  async cancelPrompt(): Promise<void> {
+  async cancelPrompt(sessionId: string): Promise<void> {
     if (!this.isConnectionInitialized || !this.connection) {
       throw new Error(
         'Connection not initialized. Call initializeConnection() first.'
       );
     }
 
-    if (!this.isSessionCreated || !this.sessionId) {
-      throw new Error('No active session. Call createSession() first.');
+    if (!this.activeSessions.has(sessionId)) {
+      throw new Error(
+        `Session '${sessionId}' not found. Call createSession() first.`
+      );
     }
 
     try {
       await this.connection.cancel({
-        sessionId: this.sessionId,
+        sessionId,
       });
 
       console.log(
-        colors.yellow(`⚠️  Prompt cancelled for session: ${this.sessionId}`)
+        colors.yellow(`⚠️  Prompt cancelled for session: ${sessionId}`)
       );
     } catch (error) {
       throw new Error(`Failed to cancel prompt: ${formatError(error)}`);
@@ -469,15 +469,20 @@ export class ACPRunner {
   /**
    * Run a single workflow step using the ACP session
    */
-  async runStep(stepId: string): Promise<ACPRunnerStepResult> {
+  async runStep(
+    sessionId: string,
+    stepId: string
+  ): Promise<ACPRunnerStepResult> {
     if (!this.isConnectionInitialized || !this.connection) {
       throw new Error(
         'Connection not initialized. Call initializeConnection() first.'
       );
     }
 
-    if (!this.isSessionCreated || !this.sessionId) {
-      throw new Error('No active session. Call createSession() first.');
+    if (!this.activeSessions.has(sessionId)) {
+      throw new Error(
+        `Session '${sessionId}' not found. Call createSession() first.`
+      );
     }
 
     const start = performance.now();
@@ -498,7 +503,7 @@ export class ACPRunner {
 
       // Log step start
       this.logger?.info('step_start', `Starting step: ${step.name}`, {
-        sessionId: this.sessionId ?? undefined,
+        sessionId,
         stepId: step.id,
         stepName: step.name,
         agent: this.tool,
@@ -514,7 +519,7 @@ export class ACPRunner {
         (isAgentStep(step) && step.model) || this.defaultModel || undefined;
       if (stepModel) {
         try {
-          await this.setModel(stepModel);
+          await this.setModel(sessionId, stepModel);
         } catch (error) {
           console.log(
             colors.yellow(
@@ -540,7 +545,7 @@ export class ACPRunner {
       }
 
       // Send the prompt via ACP session
-      const promptResult = await this.sendPrompt(prompt);
+      const promptResult = await this.sendPrompt(sessionId, prompt);
 
       // Track usage stats from ACP response
       const tokens = promptResult.tokens;
@@ -578,7 +583,7 @@ export class ACPRunner {
 
       // Log step completion
       this.logger?.info('step_complete', `Step completed: ${step.name}`, {
-        sessionId: this.sessionId ?? undefined,
+        sessionId,
         stepId: step.id,
         stepName: step.name,
         agent: this.tool,
@@ -608,7 +613,7 @@ export class ACPRunner {
 
       // Log step failure
       this.logger?.error('step_fail', `Step failed: ${step.name}`, {
-        sessionId: this.sessionId ?? undefined,
+        sessionId,
         stepId: step.id,
         stepName: step.name,
         agent: this.tool,
@@ -1053,13 +1058,13 @@ export class ACPRunner {
    * Close just the current session without closing the connection
    * This allows creating a new session on the same connection
    */
-  closeSession(): void {
-    if (this.sessionId) {
+  closeSession(sessionId: string): void {
+    if (this.activeSessions.has(sessionId)) {
       if (VERBOSE) {
-        console.log(colors.gray(`🔌 Closing session: ${this.sessionId}`));
+        console.log(colors.gray(`🔌 Closing session: ${sessionId}`));
       }
-      this.sessionId = null;
-      this.isSessionCreated = false;
+      this.activeSessions.delete(sessionId);
+      this.client?.removeSession(sessionId);
     }
   }
 
@@ -1075,8 +1080,7 @@ export class ACPRunner {
       this.agentProcess = null;
     }
     this.connection = null;
-    this.sessionId = null;
+    this.activeSessions.clear();
     this.isConnectionInitialized = false;
-    this.isSessionCreated = false;
   }
 }

--- a/packages/cli/src/lib/agents/acp-client.ts
+++ b/packages/cli/src/lib/agents/acp-client.ts
@@ -59,26 +59,51 @@ interface TerminalState {
 
 const terminals = new Map<string, TerminalState>();
 
+interface SessionCaptureState {
+  capturedMessages: string;
+  isCapturing: boolean;
+}
+
 export class ACPClient implements Client {
-  private capturedMessages: string = '';
-  private isCapturing: boolean = false;
+  private sessions = new Map<string, SessionCaptureState>();
+
+  private getOrCreateSession(sessionId: string): SessionCaptureState {
+    let session = this.sessions.get(sessionId);
+    if (!session) {
+      session = {
+        capturedMessages: '',
+        isCapturing: false,
+      };
+      this.sessions.set(sessionId, session);
+    }
+    return session;
+  }
 
   /**
    * Start capturing agent messages from session updates
    */
-  startCapturing(): void {
-    this.capturedMessages = '';
-    this.isCapturing = true;
+  startCapturing(sessionId: string): void {
+    const session = this.getOrCreateSession(sessionId);
+    session.capturedMessages = '';
+    session.isCapturing = true;
   }
 
   /**
    * Stop capturing and return accumulated messages
    */
-  stopCapturing(): string {
-    this.isCapturing = false;
-    const messages = this.capturedMessages;
-    this.capturedMessages = '';
+  stopCapturing(sessionId: string): string {
+    const session = this.getOrCreateSession(sessionId);
+    session.isCapturing = false;
+    const messages = session.capturedMessages;
+    session.capturedMessages = '';
     return messages;
+  }
+
+  /**
+   * Remove session capture state (cleanup after session close)
+   */
+  removeSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
   }
 
   requestPermission(
@@ -119,6 +144,7 @@ export class ACPClient implements Client {
 
   async sessionUpdate(params: SessionNotification): Promise<void> {
     const update = params.update;
+    const session = this.getOrCreateSession(params.sessionId);
 
     // Always log session updates for debugging
     console.error(
@@ -130,8 +156,8 @@ export class ACPClient implements Client {
       case 'agent_message_chunk':
         if (update.content.type === 'text') {
           // Capture agent messages when capturing is enabled
-          if (this.isCapturing) {
-            this.capturedMessages += update.content.text;
+          if (session.isCapturing) {
+            session.capturedMessages += update.content.text;
           }
           if (VERBOSE) {
             process.stderr.write(update.content.text);
@@ -180,8 +206,8 @@ export class ACPClient implements Client {
           }
         }
 
-        if (this.isCapturing && update.content.type === 'text') {
-          this.capturedMessages += `[THINKING] ${update.content.text}`;
+        if (session.isCapturing && update.content.type === 'text') {
+          session.capturedMessages += `[THINKING] ${update.content.text}`;
         }
         break;
       case 'usage_update':

--- a/packages/cli/src/lib/agents/acp-invoke.ts
+++ b/packages/cli/src/lib/agents/acp-invoke.ts
@@ -248,7 +248,7 @@ export async function acpInvoke(config: ACPInvokeConfig): Promise<string> {
     }
 
     // 7. Send prompt and capture response
-    client.startCapturing();
+    client.startCapturing(sessionId);
 
     if (VERBOSE) {
       console.error(
@@ -270,7 +270,7 @@ export async function acpInvoke(config: ACPInvokeConfig): Promise<string> {
       );
     }
 
-    const response = client.stopCapturing();
+    const response = client.stopCapturing(sessionId);
 
     return response;
   } catch (error) {


### PR DESCRIPTION
Refactor `ACPClient` and `ACPRunner` to support multiple concurrent ACP sessions over a single connection. Previously, a single session was tracked with instance-level state (`sessionId`, `isSessionCreated`, `capturedMessages`, cost tracking), which prevented running parallel workflow steps. Now, all per-session state is keyed by `sessionId`, allowing multiple sessions to coexist without interference.

## Changes

- Introduced `SessionCaptureState` interface in both `packages/agent` and `packages/cli` ACP clients to hold per-session capture and cost state
- Replaced single-session fields (`capturedMessages`, `isCapturing`, `cumulativeCostAmount`, etc.) with a `Map<string, SessionCaptureState>` keyed by session ID
- Updated `startCapturing()`, `stopCapturing()`, and `getLastPromptCost()` to accept a `sessionId` parameter
- Added `removeSession()` for cleanup when a session is closed
- Changed `ACPRunner` to track active sessions via `Set<string>` instead of a single `sessionId` field, removing the "session already created" guard
- Updated `sendPrompt()`, `setModel()`, `cancelPrompt()`, `runStep()`, and `closeSession()` to accept and route by `sessionId`
- Updated `createSession()` to return the session ID, allowing callers to manage multiple sessions concurrently
- Adjusted `run.ts` command to pass session IDs through the step execution flow