### PR TITLE
feat: add cost and usage tracking to output directory per step and overall task

### DIFF
--- a/packages/agent/src/commands/run.ts
+++ b/packages/agent/src/commands/run.ts
@@ -2,6 +2,7 @@ import { CommandOutput } from '../cli.js';
 import colors from 'ansi-colors';
 import {
   WorkflowManager,
+  IterationManager,
   IterationStatusManager,
   JsonlLogger,
   ProjectConfigManager,
@@ -48,6 +49,9 @@ function usageProperties(
   if (usage.cost !== undefined) {
     const currency = usage.currency ?? 'USD';
     props['Cost'] = colors.yellow(`${usage.cost.toFixed(4)} ${currency}`);
+  }
+  if (usage.agent) {
+    props['Agent'] = colors.gray(usage.agent);
   }
   if (usage.model) {
     props['Model'] = colors.gray(usage.model);
@@ -284,6 +288,7 @@ export const runCommand = async (
   // Declare status manager outside try block so it's accessible in catch
   let statusManager: IterationStatusManager | undefined;
   let totalDuration = 0;
+  let workflowUsage: UsageReport | undefined;
 
   // Determine the logs directory. Prefer /logs (bind-mounted by the sandbox
   // to the project-level logs directory), fall back to the output directory.
@@ -532,6 +537,7 @@ export const runCommand = async (
         if (failedSteps > 0) {
           output.success = false;
           output.error = runResult.error;
+          workflowUsage = runResult.usage;
           logger?.error('workflow_fail', 'Workflow completed with errors', {
             taskId: options.taskId,
             duration: runResult.totalDuration,
@@ -543,6 +549,7 @@ export const runCommand = async (
           });
         } else {
           output.success = true;
+          workflowUsage = runResult.usage;
           statusManager?.complete('Workflow completed successfully');
           logger?.info('workflow_complete', 'Workflow completed successfully', {
             taskId: options.taskId,
@@ -562,6 +569,19 @@ export const runCommand = async (
   } catch (err) {
     output.success = false;
     output.error = err instanceof Error ? err.message : `${err}`;
+  }
+
+  // Persist usage to iteration.json (versioned).
+  const finalUsage = workflowUsage;
+  if (finalUsage && options.output) {
+    try {
+      if (IterationManager.exists(options.output)) {
+        const iterManager = IterationManager.load(options.output);
+        iterManager.setUsage(finalUsage);
+      }
+    } catch {
+      // Best-effort: iteration.json may not exist in all execution contexts
+    }
   }
 
   if (!output.success) {

--- a/packages/agent/src/lib/acp-runner.ts
+++ b/packages/agent/src/lib/acp-runner.ts
@@ -574,11 +574,12 @@ export class ACPRunner {
 
       // Build usage report from ACP response
       const model = stepModel || this.defaultModel;
+      const agent = this.tool;
       let usage: UsageReport | undefined = promptResult.usage;
       if (usage) {
-        usage = { ...usage, model };
-      } else if (model) {
-        usage = { model };
+        usage = { ...usage, model, agent };
+      } else if (model || agent) {
+        usage = { model, agent };
       }
 
       if (VERBOSE) {

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -160,6 +160,9 @@ const inspectCommand = async (
       throw new TaskNotFoundError(numericTaskId);
     }
 
+    // Sync task status from the latest iteration
+    task.updateStatusFromIteration();
+
     if (iterationNumber === undefined) {
       iterationNumber = task.iterations;
     }
@@ -276,6 +279,7 @@ const inspectCommand = async (
         uuid: task.uuid,
         workflowName: task.workflowName,
         worktreePath: task.worktreePath,
+        usage: task.usage,
         source: task.source,
       };
 
@@ -337,6 +341,33 @@ const inspectCommand = async (
       };
 
       showProperties(workspaceProps);
+
+      // Usage information
+      if (task.usage) {
+        showTitle('Usage');
+
+        const usageProps: Record<string, string> = {};
+
+        if (task.usage.cost != null) {
+          const currency = task.usage.currency || 'USD';
+          usageProps['Cost'] = colors.yellow(
+            `$${task.usage.cost.toFixed(4)} ${currency}`
+          );
+        }
+
+        if (task.usage.inputTokens != null) {
+          usageProps['Input Tokens'] = task.usage.inputTokens.toLocaleString();
+        }
+        if (task.usage.outputTokens != null) {
+          usageProps['Output Tokens'] =
+            task.usage.outputTokens.toLocaleString();
+        }
+        if (task.usage.totalTokens != null) {
+          usageProps['Total Tokens'] = task.usage.totalTokens.toLocaleString();
+        }
+
+        showProperties(usageProps);
+      }
 
       // Workflow files
       const discoveredFiles = iteration.listMarkdownFiles();

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -247,7 +247,7 @@ const listCommand = async (
     // Update task status and detect completions for onComplete hooks
     for (const { task, project: projectData } of tasksWithProjects) {
       try {
-        // Update status from iteration
+        // Update status from iterations (also syncs usage on terminal states)
         task.updateStatusFromIteration();
         const currentStatus = task.status;
 

--- a/packages/cli/src/lib/autopilot/steps/__tests__/workflow.test.ts
+++ b/packages/cli/src/lib/autopilot/steps/__tests__/workflow.test.ts
@@ -24,6 +24,7 @@ const mockTask = {
   setAgentImage: vi.fn(),
   setContainerInfo: vi.fn(),
   updateStatusFromIteration: vi.fn(),
+  syncUsage: vi.fn(),
   getIterationPath: vi.fn(),
 };
 

--- a/packages/cli/src/output-types.ts
+++ b/packages/cli/src/output-types.ts
@@ -7,6 +7,7 @@ import type { IterationManager, WorkflowSource } from 'rover-core';
 import type {
   TaskDescription,
   TaskStatus as SchemaTaskStatus,
+  UsageReport,
   Workflow,
 } from 'rover-schemas';
 import type { Span, TaskMapping } from './lib/autopilot/types.js';
@@ -210,6 +211,7 @@ export interface TaskInspectionOutput {
   worktreePath: string;
   agentModel?: string;
   agentDisplay?: string;
+  usage?: UsageReport;
   source?: {
     type: 'github' | 'manual';
     id?: string;

--- a/packages/core/src/files/iteration.ts
+++ b/packages/core/src/files/iteration.ts
@@ -16,6 +16,7 @@ import {
   type Iteration,
   type IterationPreviousContext,
   type IterationContextEntry,
+  type UsageReport,
 } from 'rover-schemas';
 import { VERBOSE } from '../verbose.js';
 
@@ -166,10 +167,19 @@ export class IterationManager {
     // Migrate from 1.0 to 1.1
     // Add the mandatory `context` field with an empty array
     if (data.version === '1.0') {
+      data = {
+        ...data,
+        version: '1.1',
+        context: [],
+      };
+    }
+
+    // Migrate from 1.1 to 1.2
+    // usage field is optional, just bump version
+    if (data.version === '1.1') {
       return {
         ...data,
         version: CURRENT_ITERATION_SCHEMA_VERSION,
-        context: [],
       } as Iteration;
     }
 
@@ -250,6 +260,9 @@ export class IterationManager {
   get context(): IterationContextEntry[] {
     return this.data.context;
   }
+  get usage(): UsageReport | undefined {
+    return this.data.usage;
+  }
   get fileDescriptionPath(): string {
     return this.filePath;
   }
@@ -267,6 +280,14 @@ export class IterationManager {
    */
   updateDescription(description: string): void {
     this.data.description = description;
+    this.save();
+  }
+
+  /**
+   * Set the usage/cost report for this iteration.
+   */
+  setUsage(usage: UsageReport): void {
+    this.data.usage = usage;
     this.save();
   }
 

--- a/packages/core/src/files/task-description.ts
+++ b/packages/core/src/files/task-description.ts
@@ -28,6 +28,7 @@ import {
   type StatusMetadata,
   type TaskDescription,
   type TaskStatus,
+  type UsageReport,
 } from 'rover-schemas';
 import { VERBOSE } from '../verbose.js';
 import { IterationManager } from './iteration.js';
@@ -574,7 +575,13 @@ export class TaskDescriptionManager {
     const iteration = this.getLastIteration();
 
     if (iteration != null) {
-      const status = iteration.status();
+      let status: ReturnType<typeof iteration.status>;
+      try {
+        status = iteration.status();
+      } catch {
+        // status.json may not exist yet (iteration just started)
+        return;
+      }
       let statusName: TaskStatus;
       let timestamp;
       let error;
@@ -609,7 +616,32 @@ export class TaskDescriptionManager {
 
       const metadata = { timestamp, error };
       this.setStatus(statusName, metadata);
+
+      // When the task reaches a terminal state, sync usage from all
+      // iterations so that description.json always has the final cost.
+      if (statusName === 'COMPLETED' || statusName === 'FAILED') {
+        this.syncUsage();
+      }
     }
+  }
+
+  /**
+   * Recompute task-level usage by summing usage from all iterations.
+   * Always rebuilds from scratch so it is safe to call repeatedly.
+   */
+  syncUsage(): void {
+    const iterations = this.getIterations();
+    let total: UsageReport | undefined;
+
+    for (const iter of iterations) {
+      const iterUsage = iter.usage;
+      if (iterUsage) {
+        total = accumulateUsage(total, iterUsage);
+      }
+    }
+
+    this.data.usage = total;
+    this.save();
   }
 
   // ============================================================
@@ -755,6 +787,9 @@ export class TaskDescriptionManager {
   }
   get source(): TaskDescription['source'] {
     return this.data.source;
+  }
+  get usage(): TaskDescription['usage'] {
+    return this.data.usage;
   }
   get onCompleteHookFiredAt(): TaskDescription['onCompleteHookFiredAt'] {
     return this.data.onCompleteHookFiredAt;
@@ -965,4 +1000,46 @@ export class TaskDescriptionManager {
       );
     }
   }
+}
+
+/**
+ * Sum two UsageReport values together.
+ * If `existing` is undefined, returns `incoming` as-is.
+ * Top-level `agent` / `model` are set only when both reports agree.
+ */
+function accumulateUsage(
+  existing: UsageReport | undefined,
+  incoming: UsageReport
+): UsageReport {
+  if (!existing) return incoming;
+
+  if (
+    existing.currency &&
+    incoming.currency &&
+    existing.currency !== incoming.currency
+  ) {
+    throw new Error(
+      `Cannot accumulate usage with different currencies: ${existing.currency} vs ${incoming.currency}`
+    );
+  }
+
+  const add = (a?: number, b?: number): number | undefined =>
+    a !== undefined || b !== undefined ? (a ?? 0) + (b ?? 0) : undefined;
+
+  return {
+    inputTokens: add(existing.inputTokens, incoming.inputTokens),
+    outputTokens: add(existing.outputTokens, incoming.outputTokens),
+    totalTokens: add(existing.totalTokens, incoming.totalTokens),
+    cost: add(existing.cost, incoming.cost),
+    currency: incoming.currency ?? existing.currency,
+    agent:
+      existing.agent && incoming.agent && existing.agent === incoming.agent
+        ? existing.agent
+        : undefined,
+    model:
+      existing.model && incoming.model && existing.model === incoming.model
+        ? existing.model
+        : undefined,
+    steps: [...(existing.steps ?? []), ...(incoming.steps ?? [])],
+  };
 }

--- a/packages/core/src/files/workflow.ts
+++ b/packages/core/src/files/workflow.ts
@@ -21,6 +21,7 @@ import {
   type WorkflowConfig,
   type WorkflowAgentTool,
   type UsageReport,
+  type StepUsageReport,
   ZodError,
 } from 'rover-schemas';
 import { launchSync } from '../os.js';
@@ -636,25 +637,31 @@ export class WorkflowManager {
 /**
  * Aggregate UsageReport values across a list of step results.
  * Returns undefined if no step reported usage.
+ *
+ * Builds a per-step breakdown and sets top-level `agent` / `model`
+ * only when every step with usage reported the same value.
  */
 function aggregateUsage(stepResults: StepResult[]): UsageReport | undefined {
-  const reports = stepResults
-    .map(r => r.usage)
-    .filter((u): u is UsageReport => u !== undefined);
+  const stepsWithUsage = stepResults.filter(
+    (r): r is StepResult & { usage: UsageReport } => r.usage !== undefined
+  );
 
-  if (reports.length === 0) return undefined;
+  if (stepsWithUsage.length === 0) return undefined;
 
   let inputTokens = 0;
   let outputTokens = 0;
   let totalTokens = 0;
   let cost = 0;
   let currency: string | undefined;
-  let model: string | undefined;
 
   let hasTokens = false;
   let hasCost = false;
 
-  for (const report of reports) {
+  const models = new Set<string>();
+  const agents = new Set<string>();
+  const steps: StepUsageReport[] = [];
+
+  for (const { id, usage: report } of stepsWithUsage) {
     if (report.inputTokens !== undefined) {
       inputTokens += report.inputTokens;
       hasTokens = true;
@@ -675,8 +682,22 @@ function aggregateUsage(stepResults: StepResult[]): UsageReport | undefined {
       currency = report.currency;
     }
     if (report.model !== undefined) {
-      model = report.model;
+      models.add(report.model);
     }
+    if (report.agent !== undefined) {
+      agents.add(report.agent);
+    }
+
+    steps.push({
+      stepId: id,
+      inputTokens: report.inputTokens,
+      outputTokens: report.outputTokens,
+      totalTokens: report.totalTokens,
+      cost: report.cost,
+      currency: report.currency,
+      agent: report.agent,
+      model: report.model,
+    });
   }
 
   return {
@@ -685,6 +706,8 @@ function aggregateUsage(stepResults: StepResult[]): UsageReport | undefined {
     totalTokens: hasTokens ? totalTokens : undefined,
     cost: hasCost ? cost : undefined,
     currency: hasCost ? (currency ?? 'USD') : undefined,
-    model,
+    agent: agents.size === 1 ? [...agents][0] : undefined,
+    model: models.size === 1 ? [...models][0] : undefined,
+    steps,
   };
 }

--- a/packages/core/src/usage.ts
+++ b/packages/core/src/usage.ts
@@ -37,9 +37,8 @@ export interface ResultWithUsage<T> {
  * (multiple prompts per step) and at the workflow level
  * (multiple steps per workflow).
  *
- * Token counts and costs are summed. The model field retains the
- * last recorded value (since a step may use multiple models, the
- * caller can inspect individual reports if needed).
+ * Token counts and costs are summed. Top-level `agent` and `model`
+ * are set only when every recorded report used the same value.
  */
 export class UsageTracker {
   private reports: UsageReport[] = [];
@@ -72,10 +71,12 @@ export class UsageTracker {
     let totalTokens = 0;
     let cost = 0;
     let currency: string | undefined;
-    let model: string | undefined;
 
     let hasTokens = false;
     let hasCost = false;
+
+    const models = new Set<string>();
+    const agents = new Set<string>();
 
     for (const report of this.reports) {
       if (report.inputTokens !== undefined) {
@@ -98,7 +99,10 @@ export class UsageTracker {
         currency = report.currency;
       }
       if (report.model !== undefined) {
-        model = report.model;
+        models.add(report.model);
+      }
+      if (report.agent !== undefined) {
+        agents.add(report.agent);
       }
     }
 
@@ -108,7 +112,8 @@ export class UsageTracker {
       totalTokens: hasTokens ? totalTokens : undefined,
       cost: hasCost ? cost : undefined,
       currency: hasCost ? (currency ?? 'USD') : undefined,
-      model,
+      agent: agents.size === 1 ? [...agents][0] : undefined,
+      model: models.size === 1 ? [...models][0] : undefined,
     };
   }
 

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -214,7 +214,8 @@ export {
 } from './jsonl-log/schema.js';
 
 // Usage reporting
-export type { UsageReport } from './usage/types.js';
+export { UsageReportSchema, StepUsageReportSchema } from './usage/schema.js';
+export type { UsageReport, StepUsageReport } from './usage/types.js';
 
 // Rexport some Zod utilities so consumers do not need to depend on Zod
 export { ZodError } from 'zod';

--- a/packages/schemas/src/iteration/schema.ts
+++ b/packages/schemas/src/iteration/schema.ts
@@ -3,9 +3,10 @@
  */
 
 import { z } from 'zod';
+import { UsageReportSchema } from '../usage/schema.js';
 
 // Current schema version
-export const CURRENT_ITERATION_SCHEMA_VERSION = '1.1';
+export const CURRENT_ITERATION_SCHEMA_VERSION = '1.2';
 
 // Filename constants
 export const ITERATION_FILENAME = 'iteration.json';
@@ -97,4 +98,6 @@ export const IterationSchema = z.object({
   previousContext: IterationPreviousContextSchema,
   /** Context entries for this iteration */
   context: z.array(IterationContextEntrySchema),
+  /** Usage/cost report for this iteration */
+  usage: UsageReportSchema.optional(),
 });

--- a/packages/schemas/src/task-description/schema.ts
+++ b/packages/schemas/src/task-description/schema.ts
@@ -4,9 +4,10 @@
  */
 import { z } from 'zod';
 import { NetworkConfigSchema } from '../project-config/schema.js';
+import { UsageReportSchema } from '../usage/schema.js';
 
 // Schema version for migrations
-export const CURRENT_TASK_DESCRIPTION_SCHEMA_VERSION = '1.5';
+export const CURRENT_TASK_DESCRIPTION_SCHEMA_VERSION = '1.6';
 
 // Task status schema
 export const TaskStatusSchema = z.enum([
@@ -98,6 +99,9 @@ export const TaskDescriptionSchema = z.object({
   // Hook tracking - stores the lastStatusCheck timestamp when onComplete hook was last fired
   // Compared against lastStatusCheck to detect new terminal status transitions
   onCompleteHookFiredAt: z.string().datetime().optional(),
+
+  // Accumulated usage/cost across all iterations
+  usage: UsageReportSchema.optional(),
 
   // Metadata
   version: z.string(),

--- a/packages/schemas/src/usage/schema.ts
+++ b/packages/schemas/src/usage/schema.ts
@@ -1,0 +1,50 @@
+/**
+ * Zod schema for runtime validation of usage reports.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Schema for a single step's usage report within an iteration.
+ */
+export const StepUsageReportSchema = z.object({
+  /** Step identifier. */
+  stepId: z.string(),
+  /** Number of input tokens consumed. */
+  inputTokens: z.number().optional(),
+  /** Number of output tokens produced. */
+  outputTokens: z.number().optional(),
+  /** Total tokens (input + output + cached). */
+  totalTokens: z.number().optional(),
+  /** Monetary cost incurred. */
+  cost: z.number().optional(),
+  /** Currency of the cost value (default: USD). */
+  currency: z.string().optional(),
+  /** Agent tool used (e.g. "claude", "gemini"). */
+  agent: z.string().optional(),
+  /** Model identifier used. */
+  model: z.string().optional(),
+});
+
+/**
+ * Schema for aggregated usage/cost attached to an iteration or task.
+ * Contains totals across all steps, with an optional per-step breakdown.
+ */
+export const UsageReportSchema = z.object({
+  /** Number of input tokens consumed. */
+  inputTokens: z.number().optional(),
+  /** Number of output tokens produced. */
+  outputTokens: z.number().optional(),
+  /** Total tokens (input + output + cached). */
+  totalTokens: z.number().optional(),
+  /** Monetary cost incurred. */
+  cost: z.number().optional(),
+  /** Currency of the cost value (default: USD). */
+  currency: z.string().optional(),
+  /** Agent tool — set only when all steps used the same agent. */
+  agent: z.string().optional(),
+  /** Model identifier — set only when all steps used the same model. */
+  model: z.string().optional(),
+  /** Per-step usage breakdown. */
+  steps: z.array(StepUsageReportSchema).optional(),
+});

--- a/packages/schemas/src/usage/types.ts
+++ b/packages/schemas/src/usage/types.ts
@@ -1,23 +1,21 @@
 /**
  * Usage reporting types for tracking token consumption and cost
  * across ACP invocations, steps, and workflows.
+ *
+ * All types are inferred from Zod schemas to ensure consistency.
  */
 
+import type { z } from 'zod';
+import type { UsageReportSchema, StepUsageReportSchema } from './schema.js';
+
 /**
- * A snapshot of resource usage from a single ACP invocation or
- * an accumulation across multiple invocations.
+ * Aggregated usage across all steps, with optional per-step breakdown.
+ * Top-level `agent` and `model` are populated only when every step
+ * used the same value.
  */
-export interface UsageReport {
-  /** Number of input tokens consumed. */
-  inputTokens?: number;
-  /** Number of output tokens produced. */
-  outputTokens?: number;
-  /** Total tokens (input + output + cached). */
-  totalTokens?: number;
-  /** Monetary cost incurred. */
-  cost?: number;
-  /** Currency of the cost value (default: USD). */
-  currency?: string;
-  /** Model identifier used. */
-  model?: string;
-}
+export type UsageReport = z.infer<typeof UsageReportSchema>;
+
+/**
+ * Usage report for a single workflow step.
+ */
+export type StepUsageReport = z.infer<typeof StepUsageReportSchema>;


### PR DESCRIPTION
Add usage and cost tracking throughout the task lifecycle. Each iteration now records its usage (tokens, cost, model, agent) in `iteration.json`, and the task description aggregates usage across all iterations. The `inspect` command displays a new Usage section, and the `list` command syncs usage on every refresh.

## Changes

### Schemas (`packages/schemas`)
- Added `UsageReportSchema` and `StepUsageReportSchema` Zod schemas in `packages/schemas/src/usage/schema.ts`
- `UsageReport` and `StepUsageReport` types are now inferred from Zod schemas (`z.infer<typeof ...>`) instead of manually defined interfaces
- Bumped `IterationSchema` to v1.2 with an optional `usage` field
- Bumped `TaskDescriptionSchema` to v1.6 with an optional `usage` field
- Exported `UsageReportSchema`, `StepUsageReportSchema`, and `StepUsageReport` from the package index

### Core (`packages/core`)
- `IterationManager` gains `usage` getter and `setUsage()` method; added migration from v1.1 → v1.2
- `TaskDescriptionManager.updateStatusFromIteration()` now catches missing `status.json` gracefully and calls `syncUsage()` on terminal states
- Added `TaskDescriptionManager.syncUsage()` that rebuilds task-level usage by summing iteration data via `accumulateUsage()`
- Added `usage` getter to `TaskDescriptionManager`
- Added private `accumulateUsage()` helper that sums two `UsageReport` values, resolving `agent`/`model` only when all reports agree
- `aggregateUsage` in `WorkflowManager` now builds a per-step `StepUsageReport[]` breakdown and resolves top-level `agent`/`model` only when all steps agree
- `UsageTracker` now tracks `agent` alongside `model`, with the same single-value-when-unanimous resolution strategy

### Agent (`packages/agent`)
- `runCommand` persists `workflowUsage` to `iteration.json` via `IterationManager.setUsage()`
- ACP runner attaches `agent` (tool name) to usage reports alongside `model`
- `run` command displays Agent in usage properties output

### CLI (`packages/cli`)
- `inspect` command calls `task.updateStatusFromIteration()` before display, includes `usage` in output, and renders a new Usage section (cost, input/output/total tokens)
- `list` command comment updated to reflect usage sync on terminal states
- Added `usage` field to `TaskInspectionOutput` interface

## Notes

- The task description schema version was bumped from `1.5` to `1.6`; iteration schema from `1.1` to `1.2`.
- Top-level `agent` and `model` on aggregated reports are intentionally set only when **all** contributing steps/iterations used the same value; otherwise they are left undefined.
- Usage is persisted only in `iteration.json` (versioned); `status.json` is not modified with cost data.